### PR TITLE
2017.9.1 release candidate

### DIFF
--- a/WebRoot/Config.jsp
+++ b/WebRoot/Config.jsp
@@ -141,6 +141,7 @@ instructorsCanProvision = Utils.pluginSettings.getInstructorsCanProvision();
 mailLectureNotifications = Utils.pluginSettings.getMailLectureNotifications();
 refreshLogins = Utils.pluginSettings.getRefreshLogins();
 syncAvailabilityStatus = Utils.pluginSettings.getSyncAvailabilityStatus();
+redirectToDefaultLogin = Utils.pluginSettings.getRedirectToDefaultLogin();
 grantTACreator = Utils.pluginSettings.getGrantTACreator();
 grantTAProvision = Utils.pluginSettings.getGrantTAProvision();
 TAsCanCreateLinks = Utils.pluginSettings.getTAsCanCreateLinks();

--- a/WebRoot/WEB-INF/bb-manifest.xml
+++ b/WebRoot/WEB-INF/bb-manifest.xml
@@ -5,7 +5,7 @@
         <description value="Provision Panopto courses from Blackboard.  View live listing of available Panopto content from within the associated Blackboard course.  Import Panopto lecture links as Blackboard content items." />
         <handle value="PanoptoCourseTool" />
         <webapp-type value="javaext" />
-        <version value="2017.7.1" />
+        <version value="2017.9.1" />
         <requires>
             <bbversion value="9.1" />
         </requires>

--- a/WebRoot/vtbe/mashup.jsp
+++ b/WebRoot/vtbe/mashup.jsp
@@ -79,7 +79,7 @@ function AlertAndClose(){
 					                    var returnString = "";
 					                    //Add iframe html for each video to form
 					                    message.ids.each(function (value) {
-					                        var iframeString = "<iframe src=\"https://<%=serverName%>/Panopto/Pages/Embed.aspx?instance=<%=Utils.pluginSettings.getInstanceName()%>&id=" + value + "&v=1\" width=\"720\" height=\"480\" style=\"max-width: 100%; max-height: 100%;\" frameborder=\"0\"></iframe><br>";
+					                        var iframeString = "<iframe src=\"https://<%=serverName%>/Panopto/Pages/Embed.aspx?instance=<%=Utils.pluginSettings.getInstanceName()%>&id=" + value + "&v=1\" width=\"720\" height=\"480\" style=\"max-width: 100%; max-height: 100%;\" frameborder=\"0\" allowfullscreen></iframe><br>";
 					                        returnString += iframeString;
 					                    });
 					                    document.getElementById("embedHtml").value = returnString;

--- a/src/main/com/panopto/blackboard/PanoptoVersions.java
+++ b/src/main/com/panopto/blackboard/PanoptoVersions.java
@@ -25,6 +25,7 @@ class PanoptoVersions {
 
     static final PanoptoVersion V4_9 = PanoptoVersion.from("4.9");
     static final PanoptoVersion V5_3 = PanoptoVersion.from("5.3");
+    static final PanoptoVersion V5_4 = PanoptoVersion.from("5.4");
 
     //Determines whether or not the block is able to call session or folder availability window API methods
     //based on the version of the current Panopto server.
@@ -41,6 +42,15 @@ class PanoptoVersions {
      */
     static boolean canCallCopyApiMethods(PanoptoVersion panoptoVersion) {
         return panoptoVersion.compareTo(V5_3) >= 0;
+    }
+    
+    /**
+     * Determine if the panopto server version supports Reporting integration info (5.4 and above)
+     * @param panoptoVersion Version of Panopto we are pointed at
+     * @return boolean true if we have at least the minimum version number
+     */
+    static boolean canReportIntegrationInfo(PanoptoVersion panoptoVersion) {
+        return panoptoVersion.compareTo(V5_4) >= 0;
     }
 
     /**


### PR DESCRIPTION
- Fixed API call failure which happened with Panopto server 5.3.1 or before.
- Fixed a bug where "Redirect to Default Blackboard Login" would not be retrieved by the Config page properly, causing the user to possibly overwrite and turn the toggle off.