### PR TITLE
2017.10.1 release candidate

### DIFF
--- a/WebRoot/WEB-INF/bb-manifest.xml
+++ b/WebRoot/WEB-INF/bb-manifest.xml
@@ -5,7 +5,7 @@
         <description value="Provision Panopto courses from Blackboard.  View live listing of available Panopto content from within the associated Blackboard course.  Import Panopto lecture links as Blackboard content items." />
         <handle value="PanoptoCourseTool" />
         <webapp-type value="javaext" />
-        <version value="2017.9.1" />
+        <version value="2017.10.1" />
         <requires>
             <bbversion value="9.1" />
         </requires>

--- a/WebRoot/course/left_frame.jsp
+++ b/WebRoot/course/left_frame.jsp
@@ -93,14 +93,16 @@ form[name=searchForm]
 <SCRIPT>
     function searchNow() 
     {
-      if (document.searchForm.search_string.value=="")
-       {
-         alert('${bbNG:EncodeLabel(viewcatalogSearchCriteriaWarning)}');
-       }
-       else
-       {
-         document.forms.searchForm.submit();
-       }
+        if (document.searchForm.search_string.value == "")
+        {
+            alert('${bbNG:EncodeLabel(viewcatalogSearchCriteriaWarning)}');
+        }
+        else
+        {
+            document.forms.searchForm.submit();
+            
+            location.reload();
+        }
     }
 
     function changeOptions(f, options) {


### PR DESCRIPTION
- Updated the behavior of synchronizing a course to honor the start and end date if Panopto block is configured to consider course availability.
- Fixed an issue where the course search window was only able to be used once before needing to either refresh or close/ and re-open the search frame.