### PR TITLE
2018.6.1 release code

### DIFF
--- a/WebRoot/WEB-INF/bb-manifest.xml
+++ b/WebRoot/WEB-INF/bb-manifest.xml
@@ -5,7 +5,7 @@
         <description value="Provision Panopto courses from Blackboard.  View live listing of available Panopto content from within the associated Blackboard course.  Import Panopto lecture links as Blackboard content items." />
         <handle value="PanoptoCourseTool" />
         <webapp-type value="javaext" />
-        <version value="2018.5.1" />
+        <version value="2018.6.1" />
         <requires>
             <bbversion value="9.1" />
         </requires>

--- a/WebRoot/vtbe/assignmentMashup.jsp
+++ b/WebRoot/vtbe/assignmentMashup.jsp
@@ -49,10 +49,11 @@ function AlertAndClose(){
                             courseKey = "<%=course_key%>",
                             linkChunk = "/webapps/ppto-PanoptoCourseTool-BBLEARN/vtbe/ltiFrameContainer.jsp?view_sandbox=true&course_key=" + courseKey + "&course_id=" + courseId,
                             step1String = "Prepare your video in Panopto video library. If it's not ready, click <a href='" + linkChunk + "' target='_blank'>here</a> to navigate to your personal folder in Panopto.",
-                            step2String = "In the text editor expand \"Mashups\" and select \"Panopto Student Video Submission\".",
-                            step3String = "If your submission is not in the default personal folder select the folder where your submission is stored.",
-                            step4String = "Once at the folder your submission is located select the submission and click \"Insert\".",
-                            step5String = "Once your submission has been added to the text editor add any extra information and submit.";
+                            step2String = "Videos are submitted as part of assignments via clicking on \"Write Submission\".",
+                            step3String = "In the text editor expand \"Mashups\" and select \"Panopto Student Video Submission\".",
+                            step4String = "If your submission is not in the default personal folder select the folder where your submission is stored.",
+                            step5String = "Once at the folder your submission is located select the submission and click \"Insert\".",
+                            step6String = "Once your submission has been added to the text editor add any extra information and submit.";
                         
                         instructions += 
                         "<div>" +
@@ -61,6 +62,7 @@ function AlertAndClose(){
                             "<div><b>Step 3:</b> " + step3String + "</div>" +
                             "<div><b>Step 4:</b> " + step4String + "</div>" +
                             "<div><b>Step 5:</b> " + step5String + "</div>" +
+                            "<div><b>Step 6:</b> " + step6String + "</div>" +
                         "</div>";
                         
                         document.getElementById("embedHtml").value = instructions;


### PR DESCRIPTION
This is summer 2018 stable release of the Panopto plug-in for Blackboard.

Panopto tested this with Blackboard 4Q 2017 and 2Q 2017. Panopto will soon test this with Blackboard 2Q 2018 and post the results to this page when testing completes.

Below is the list of updates from the previous stable release (October 2017 Update 1).
- Added a Panopto tool to the "Build Content" menu. ([support doc](https://support.panopto.com/s/article/Embed-Content-into-the-build-in-Blackboard))
- Added a new assignment workflow to allow student recordings in Panopto to be submitted directly from Blackboard. (Requires Panopto server 5.7.0 and Blackboard 4Q 2017.) ([support doc](https://support.panopto.com/s/article/Assignment-Submission-Workflow-in-Blackboard))
- Extended the support of course copy to "Copy Course Materials into a New Course" and "Copy Course with Users (Exact Copy)" modes. ([support doc](https://support.panopto.com/s/article/Blackboard-Course-Copy-Permissions))
- Fixed an issue in course provisioning where the course picker does not show courses which are not yet published to students.
- Added a button to return to the course page after configuring Panopto, simplifying the workflow for most users.
- Added support for embedding Playlists from Panopto. (Panopto server 5.6.0 is minimum requirement.)
