### PR TITLE
2018.11.1 beta release candidate

### DIFF
--- a/WebRoot/Content.jsp
+++ b/WebRoot/Content.jsp
@@ -43,6 +43,8 @@ String courseConfigURL = PlugInUtil.getUri("ppto", "PanoptoCourseTool", Utils.co
 String courseResetURL = PlugInUtil.getUri("ppto", "PanoptoCourseTool", Utils.courseResetURL)
                             + "?course_id=" + course_id;
 
+String courseUrl = "/webapps/blackboard/execute/launcher?type=Course&id=" + course_id;
+
 PanoptoData ccCourse = new PanoptoData(ctx);
 
 Boolean courseHasBeenReset = false;
@@ -52,6 +54,15 @@ Boolean useOldLayout = false;
 %>
     <bbNG:learningSystemPage>
         <bbNG:cssFile href="css/main.css" />
+        <c:set var="courseBreadcrumb" value="Course"/>
+        <c:set var="pageTitle" value="Panopto Content" />
+        <bbNG:pageHeader>
+        	<bbNG:breadcrumbBar environment="COURSE">
+          		<bbNG:breadcrumb title="${courseBreadcrumb}" href="<%=courseUrl%>"/>
+        		<bbNG:breadcrumb title="${pageTitle}"/>
+        	</bbNG:breadcrumbBar>
+            <bbNG:pageTitleBar title="${pageTitle}" />
+        </bbNG:pageHeader>
             <style>
             #containerdiv
             {
@@ -203,7 +214,7 @@ Boolean useOldLayout = false;
                                                                 [<a href="javascript:launchNotes('<%=s.getNotesURL()%>')"
                                                                 >take notes</a
                                                                                                                         >]
-                                                   [<a href="<%= s.getViewerUrl()%>" onclick="return startSSO(this)"
+                                                   [<a href="<%= s.getViewerUrl() + "&instance=" + Utils.pluginSettings.getInstanceName()%>" onclick="return startSSO(this)"
                                                              >watch live</a
                                                             >]
                                                                 </span>
@@ -223,7 +234,7 @@ Boolean useOldLayout = false;
                                             else
                                             {
                                                 %><div class="completedRecording">
-                                                      <a href="<%=s.getViewerUrl()%>" onclick="return startSSO(this)">
+                                                      <a href="<%=s.getViewerUrl() + "&instance=" + Utils.pluginSettings.getInstanceName()%>" onclick="return startSSO(this)">
                                                        <%=s.getName()%>
                                                       </a>
                                                      </div><%

--- a/WebRoot/WEB-INF/bb-manifest.xml
+++ b/WebRoot/WEB-INF/bb-manifest.xml
@@ -5,7 +5,7 @@
         <description value="Provision Panopto courses from Blackboard.  View live listing of available Panopto content from within the associated Blackboard course.  Import Panopto lecture links as Blackboard content items." />
         <handle value="PanoptoCourseTool" />
         <webapp-type value="javaext" />
-        <version value="2018.8.1" />
+        <version value="2018.11.1" />
         <requires>
             <bbversion value="9.1" />
         </requires>

--- a/WebRoot/content/mashup.jsp
+++ b/WebRoot/content/mashup.jsp
@@ -8,23 +8,12 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
 
-<script>
-//Script to alert user and close window if course is not provisioned
-function AlertAndClose(){
-    alert("This course is not provisioned with Panopto. Before a course can be used with Panopto it must be setup. Please contact your administrator or instructor.");
-    self.close();
-}
-</script>
 
 <bbData:context id="ctx">
 
 <%
     //Get course information from page context
     PanoptoData ccCourse = new PanoptoData(ctx);
-
-    if(ccCourse.equals(null)){%>
-        <script> AlertAndClose();</script>
-    <%}
 
     String returnUrl = ctx.getRequestUrl();
     
@@ -36,6 +25,18 @@ function AlertAndClose(){
     } else {
         returnUrl += "?course_id=" + ctx.getCourseId();
     }
+    
+    %><script>
+    //Script to alert user and close window if course is not provisioned
+    function AlertAndRedirect(){
+        alert("This course is not provisioned with Panopto. Before a course can be used with Panopto it must be setup. Please contact your administrator or instructor.");
+        window.location = "<%=returnUrl%>";
+    }
+    </script><%
+
+    if(ccCourse.equals(null)){%>
+        <script> AlertAndRedirect();</script>
+    <%}
     
     String serverName = ccCourse.getServerName();
     Folder[] PanoptoFolders = ccCourse.getFolders();
@@ -56,13 +57,13 @@ function AlertAndClose(){
         }
         else if(folderCount == 0){
         %>
-            <script> AlertAndClose();</script>
+            <script> AlertAndRedirect();</script>
         <% 
         }
     }
     else{
     %>
-    <script> AlertAndClose();</script>
+    <script> AlertAndRedirect();</script>
     <%
     }
     //Generate source URL for iframe from info. Blackboard embeds require https

--- a/src/main/com/panopto/blackboard/PanoptoData.java
+++ b/src/main/com/panopto/blackboard/PanoptoData.java
@@ -772,7 +772,7 @@ public class PanoptoData {
                         String strDisplayName = Utils.escapeHTML(session.getName());
 
                         result.append("<option");
-                        result.append(" value='" + session.getViewerUrl() + "'");
+                        result.append(" value='" + session.getViewerUrl() + "&instance=" + Utils.pluginSettings.getInstanceName() + "'");
                         result.append(">");
                         result.append(strDisplayName);
                         result.append("</option>\n");


### PR DESCRIPTION
This is the latest beta release of the Panopto plug-in for Blackboard. Use this beta version if you are affected by any of the problems described below.

Below is the list of updates from the previous beta release (August 2018 Update 1).
- Fixed an issue where the content mashup tool did not redirect back to the Blackboard course if the course was not yet provisioned with Panopto and the user was warned.
- Fixed an issue where the side navbar did not reappear if the window was shrunk and then grown back to a larger width.
- Fixed an issue where Panopto embedded video denied the access even the user has enrolled the course, which happened under limited condition.
