### PR TITLE
release code for 2019.11.1

### DIFF
--- a/WebRoot/Config.jsp
+++ b/WebRoot/Config.jsp
@@ -78,6 +78,7 @@ Boolean insertLinkOnProvision = (request.getParameter("insertLinkOnProvision") !
 String menuLinkText = request.getParameter("menuLinkText");
 String roleMappingString = request.getParameter("roleMappingString");
 Boolean courseCopyEnabled = (request.getParameter("courseCopyEnabled") != null);
+String maxListedFolders = request.getParameter("maxListedFolders");
 
 //Bounce page address to copy into Panopto
 String SSOAddress = "https://" + ctx.getHostName()  + PlugInUtil.getUri("ppto", "PanoptoCourseTool", "SSO.jsp");
@@ -88,10 +89,10 @@ List<Role> customRoles = new ArrayList<Role>();
 
 for(Role courseRole: courseRoles)
 {
-if(courseRole.getDbRole().isRemovable())
-{
-customRoles.add(courseRole);
-}
+	if(courseRole.getDbRole().isRemovable())
+	{
+		customRoles.add(courseRole);
+	}
 }
 
 
@@ -101,29 +102,33 @@ if(instanceName != null)
     {
         Utils.pluginSettings.setInstanceName(instanceName.trim());
     }
-    
-    Utils.pluginSettings.setInstructorsCanProvision(instructorsCanProvision);
-    Utils.pluginSettings.setMailLectureNotifications(mailLectureNotifications);
-    Utils.pluginSettings.setRefreshLogins(refreshLogins);
-    Utils.pluginSettings.setSyncAvailabilityStatus(syncAvailabilityStatus);
-    Utils.pluginSettings.setRedirectToDefaultLogin(redirectToDefaultLogin);
-    Utils.pluginSettings.setGrantTACreator(grantTACreator);
-    Utils.pluginSettings.setGrantTAProvision(grantTAProvision);
-    Utils.pluginSettings.setTAsCanCreateLinks(TAsCanCreateLinks);
-    Utils.pluginSettings.setCourseResetEnabled(courseResetEnabled);
-    Utils.pluginSettings.setVerbose(verbose);
-    Utils.pluginSettings.setInsertLinkOnProvision(insertLinkOnProvision);
-    Utils.pluginSettings.setCourseCopyEnabled(courseCopyEnabled);
-    
-    if(roleMappingString != null)
-    {
-        Utils.pluginSettings.setRoleMappingString(roleMappingString.trim());
-    }
-    else
-    {
-        Utils.pluginSettings.setRoleMappingString("");
-    }
+
+	Utils.pluginSettings.setInstructorsCanProvision(instructorsCanProvision);
+	Utils.pluginSettings.setMailLectureNotifications(mailLectureNotifications);
+	Utils.pluginSettings.setRefreshLogins(refreshLogins);
+	Utils.pluginSettings.setSyncAvailabilityStatus(syncAvailabilityStatus);
+	Utils.pluginSettings.setRedirectToDefaultLogin(redirectToDefaultLogin);
+	Utils.pluginSettings.setGrantTACreator(grantTACreator);
+	Utils.pluginSettings.setGrantTAProvision(grantTAProvision);
+	Utils.pluginSettings.setTAsCanCreateLinks(TAsCanCreateLinks);
+	Utils.pluginSettings.setCourseResetEnabled(courseResetEnabled);
+	Utils.pluginSettings.setVerbose(verbose);
+	Utils.pluginSettings.setInsertLinkOnProvision(insertLinkOnProvision);
+	Utils.pluginSettings.setCourseCopyEnabled(courseCopyEnabled);
+	
+	maxListedFolders = (maxListedFolders == null) || maxListedFolders.isEmpty() ? Utils.pluginSettings.getMaxListedFolders() : maxListedFolders;
+	Utils.pluginSettings.setMaxListedFolders(Integer.toString(Integer.max(100, Integer.parseInt(maxListedFolders))));
+	
+	if(roleMappingString != null)
+	{
+	    Utils.pluginSettings.setRoleMappingString(roleMappingString.trim());
+	}
+	else
+	{
+	    Utils.pluginSettings.setRoleMappingString("");
+	}
 }
+
  
 //If menu link text is not null, save it.
 if(menuLinkText != null)
@@ -151,6 +156,7 @@ insertLinkOnProvision = Utils.pluginSettings.getInsertLinkOnProvision();
 menuLinkText = Utils.pluginSettings.getMenuLinkText();
 roleMappingString = Utils.pluginSettings.getRoleMappingString();
 courseCopyEnabled = Utils.pluginSettings.getCourseCopyEnabled();
+maxListedFolders = Utils.pluginSettings.getMaxListedFolders();
 
 // Server list form submitted, add/remove servers if valid operation
 String add_hostname = request.getParameter("add_hostname");
@@ -444,166 +450,22 @@ else
                         <div class="field">
                             <p tabIndex="0" class="stepHelp">
                                 The instance name identifies this Blackboard system to Panopto.<br />
-                                If this is the only Blackboard system that will connect to the Panopto servers below, it is not necessary to change the default ("blackboard"). 
+                                If this is the only Blackboard system that will connect to the Panopto servers above, it is not necessary to change the default ("blackboard"). 
                             </p>
                         </div>
                     </li>
-                      <li>
+                    <li>
                         <div class="label">Bounce Page URL</div>
                         <div class="field"><b><%= SSOAddress %></b></div>
                     </li>
                     <li>
                         <div class="field">
                             <p tabIndex="0" class="stepHelp">
-                                Use this address for the bounce page URL in for your Blackboard instance in the service provider section of your Panopto server.
+                                Use this address for the bounce page URL in for your Blackboard instance in the Identity Provider section of your Panopto server.
                             </p>
                         </div>
                     </li>
-                    <li>
-                        <div class="field"></div>
-                    </li>
-                    <li>
-                        <div class="label">Instructors may provision courses</div>
-                        <div class="field"><input name="instructorsCanProvision" type="checkbox" <%= instructorsCanProvision ? "checked" : "" %> style="float:left" /></div>
-                    </li>
-                    <li>
-                        <div class="field">
-                            <p tabIndex="0" class="stepHelp">
-                                This setting determines whether instructors are entitled to add courses to Panopto.<br/>
-                                If checked, instructors will be able to create content for their course with the Panopto Recorder.<br/>
-                                If unchecked, only administrators (users entitled to configure tools at the system level) will be able to add courses to Panopto.
-                            </p>
-                        </div>
-                    </li>
-                    <li>
-                        <div class="field"></div>
-                    </li>
-                    <li>
-                        <div class="label">Email Instructors</div>
-                        <div class="field">
-                            <input name="mailLectureNotifications" type="checkbox" <%= mailLectureNotifications ? "checked" : "" %> style="float:left" />
-                        </div>
-                    </li>
-                    <li>
-                        <div class="field">
-                            <p tabIndex="0" class="stepHelp">
-                                This setting determines whether an email is automatically sent to instructors when lectures are processed and ready to view.<br/>
-                                This default may be overridden for individual users via the account settings page in Panopto, after adding a course to Panopto or syncing users.
-                            </p>
-                        </div>
-                    </li>
-                    <li>
-                        <div class="field"></div>
-                    </li>
-                    <li>
-                        <div class="label">Refresh Logins</div>
-                        <div class="field">
-                            <input name="refreshLogins" type="checkbox" <%= refreshLogins ? "checked" : "" %> style="float:left" />
-                        </div>
-                    </li>
-                    <li>
-                        <div class="field">
-                            <p tabIndex="0" class="stepHelp">
-                                This setting determines whether to refresh credentials for users logging in from the Panopto Recorder.<br/>
-                                Normally, this should be left checked, so that when one Blackboard user logs out and another logs in,
-                                the Recorder will switch to the new user.<br/>
-                                <br/>
-                                However, if Panopto site cannot redirect to Blackboard SSO page automatically with some reason, 
-                                this behavior may cause unauthenticated users to be prompted to login twice when logging into the Panopto Recorder.<br/>
-                                In this case, disable this setting and instruct your users to exit the Panopto Recorder to complete the logout process.
-                                <br/>
-                                <br/>
-                            </p>
-                        </div>
-                    </li>
-                    <li>
-                        <div class="field"></div>
-                    </li>
-                    <li>
-                        <div class="label">Synchronize course availability status</div>
-                        <div class="field">
-                            <input name="syncAvailabilityStatus" type="checkbox" <%= syncAvailabilityStatus ? "checked" : "" %> style="float:left" />
-                        </div>
-                    </li>
-                    <li>
-                        <div class="field">
-                            <p tabIndex="0" class="stepHelp">
-                                This setting enables to reflect the course availability and user enrollment status to access control of Panopto permissions.
-                                <br />
-                                Warning: If this setting is enabled, then the students will lose Panopto permission for inactive courses.
-                                <br/>
-                                <br/>
-                            </p>
-                        </div>
-                    </li>
-                    <li>
-                        <div class="label">Redirect to Blackboard Default Login</div>
-                        <div class="field">
-                            <input name="redirectToDefaultLogin" type="checkbox" <%= redirectToDefaultLogin ? "checked" : "" %> style="float:left" />
-                        </div>
-                    </li>
-                    <li>
-                        <div class="field">
-                            <p tabIndex="0" class="stepHelp">
-                                This setting determines if the SSO forces a redirection to the default login page instead of the relogin URL that was provided. <br />
-                                Enable this feature only if Panopto support advises it. 
-                                <br/>
-                                <br/>
-                            </p>
-                        </div>
-                    </li>
-                    <li>
-                        <div class="field"></div>
-                    </li>
-                    <li>
-                        <div class="label">Grant TA Creator Access</div>
-                        <div class="field">
-                            <input id="grantTACreator" name="grantTACreator" type="checkbox" <%= grantTACreator ? "checked" : "" %> style="float:left" />
-                        </div>
-                    </li>
-                    <li>
-                        <div class="field">
-                            <p tabIndex="0" class="stepHelp">
-                                This setting determines whether teaching assistants are granted creator access in Panopto.<br/>
-                                If checked TAs will be able to create, edit, and delete recordings. 
-                                In addition to this global setting this can be overridden on a course by course basis.
-                                <br/>
-                                <br/>
-                            </p>
-                        </div>
-                    </li>
-                    <li>
-                        <div class="label">Allow TAs to Create Panopto Course Tool Links</div>
-                        <div class="field">
-                            <input name="TAsCanCreateLinks" type="checkbox" <%= TAsCanCreateLinks ? "checked" : "" %> style="float:left" />
-                        </div>
-                    </li>
-                    <li>
-                        <div class="field">
-                            <p tabIndex="0" class="stepHelp">
-                                This setting determines whether teaching assistants have the ability to create Panopto Course Tool Links on a course's Course Menu.<br/>
-                                 If checked, TAs will be able to create links regardless of whether they have creator access or course provisioning access.              
-                                <br/>
-                                <br/>
-                            </p>
-                        </div>
-                    </li>
-                    <li>
-                        <div class="label">Grant TA Provisioning Access</div>
-                        <div class="field">
-                            <input id="grantTAProvision" name="grantTAProvision" type="checkbox" <%= grantTAProvision ? "checked" : "" %> style="float:left" />
-                        </div>
-                    </li>
-                    <li>
-                        <div class="field">
-                            <p tabIndex="0" class="stepHelp">
-                                This setting determines whether teaching assistants are granted provisioning access in the Panopto block.<br/>
-                                If checked TAs will be able to provision courses and create links. 
-                                <br/>
-                                <br/>
-                            </p>
-                        </div>
-                    </li>
+                    
                     <li>
                         <div class="label">Panopto link on course menu when provisioned</div>
                         <div class="field">
@@ -629,6 +491,193 @@ else
                         <div class="field">
                             <p tabIndex="0" class="stepHelp">
                               Text of link to Panopto content generated on provision, if setting is selected. Default text is "Panopto Video"<br/>
+                                <br/>
+                                <br/>
+                            </p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="label">Instructors may provision courses</div>
+                        <div class="field"><input name="instructorsCanProvision" type="checkbox" <%= instructorsCanProvision ? "checked" : "" %> style="float:left" /></div>
+                    </li>
+                    <li>
+                        <div class="field">
+                            <p tabIndex="0" class="stepHelp">
+                                This setting determines whether instructors can provision their Blackboard courses to create Panopto folders.<br/>
+                                If checked, instructors will be able to configure courses on their own.<br/>
+                                If unchecked, instructors will come across an error when attempting to provision a course. Administrators (users entitled to configure tools at the system level) will need to assist them.
+                            </p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="label">Grant TA Provisioning Access</div>
+                        <div class="field">
+                            <input id="grantTAProvision" name="grantTAProvision" type="checkbox" <%= grantTAProvision ? "checked" : "" %> style="float:left" />
+                        </div>
+                    </li>
+                    <li>
+                        <div class="field">
+                            <p tabIndex="0" class="stepHelp">
+                                This setting determines whether teaching assistants are granted provisioning access in the Panopto block.<br/>
+                                If checked TAs will be able to provision courses and create links.<br />
+                                If unchecked, they will receive an error "Please contact your administrator or instructor."
+                                <br/>
+                                <br/>
+                            </p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="label">Grant TA Creator Access</div>
+                        <div class="field">
+                            <input id="grantTACreator" name="grantTACreator" type="checkbox" <%= grantTACreator ? "checked" : "" %> style="float:left" />
+                        </div>
+                    </li>
+                    <li>
+                        <div class="field">
+                            <p tabIndex="0" class="stepHelp">
+                                This setting determines whether teaching assistants are granted creator access in Panopto.<br/>
+                                If checked TAs will be able to create, edit, and delete recordings.
+                                <br/>
+                                <br/>
+                            </p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="label">Allow TAs to Create Panopto Course Tool Links</div>
+                        <div class="field">
+                            <input name="TAsCanCreateLinks" type="checkbox" <%= TAsCanCreateLinks ? "checked" : "" %> style="float:left" />
+                        </div>
+                    </li>
+                    <li>
+                        <div class="field">
+                            <p tabIndex="0" class="stepHelp">
+                                This setting determines whether teaching assistants have the ability to create Panopto Course Tool Links on a course's Course Menu.<br/>
+                                 If checked, TAs will be able to create links regardless of whether they have creator access or course provisioning access.              
+                                <br/>
+                                <br/>
+                            </p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="label">Assign custom role mappings</div>
+                        <div class="field">
+                            <input name="roleMappingString" type="text" size="30" value="<%= roleMappingString %>" style="float:left" />
+                        </div>
+                    </li>
+                    <li>
+                        <div class="field">
+                            <p tabIndex="0" class="stepHelp">
+                            Define mappings between custom blackboard roles and the blackboard roles they are recognized by the Panopto block.<br/>
+                            The syntax for mappings is [custom role ID]:[mapped role type], with each mapping separated by a ';'. <br/>
+                            The available role types to map to are 'instructor', 'ta', and 'none' with any unmapped custom roles being recognized<br/>
+                            as students by the Panopto block. Role specified as 'none' gets no access to the Panopto folder associated with the course.<br/><br/>
+                            
+                            An example mapping string would be: 'RoleID1:instructor;RoleID2:ta;RoleID3:none' (Note: case does not matter)<br/><br/>
+                            
+                            The custom roles available to be mapped are the following:<br/></p>
+	                        <div id = "rolesList">
+	                            <table>
+	                                <tr>
+	                                    <th class="customRoleCell">Role Type</th>
+	                                    <th class="customRoleCell">Role ID</th>
+	                                </tr>
+	                                  <% for(Role customRole:customRoles)
+	                                    { %>
+	                                        <tr>
+	                                            <td class="customRoleCell">
+	                                            <%=customRole.getDbRole().getCourseName()%>
+	                                            </td>
+	                                            <td class = "customRoleCell">
+	                                            <%=customRole.getIdentifier()%>
+	                                            </td>
+	                                        </tr>
+	                                <% } %>
+	                            </table>
+	                         </div>   
+	                        <br/>
+	                        <br/>
+	                        <br/>
+                        </div>
+                    </li>                    
+                    <li>
+                        <div class="label">Blackboard course copy also copies Panopto permissions</div>
+                        <div class="field">
+                            <input name="courseCopyEnabled" type="checkbox" <%= courseCopyEnabled ? "checked" : "" %> style="float:left" />
+                        </div>
+                    </li>
+                    <li>
+                        <div class="field">
+                            <p tabIndex="0" class="stepHelp">
+                                This setting determines whether users enrolled in the new course can see Panopto content created for the old course when Blackboard courses are copied.<br/>
+                                If checked the Panopto Viewer and Creator groups from the new course folder are added to the old course's folder as 'viewer' groups.
+                                <br/>
+                                <br/>
+                            </p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="label">Synchronize course availability status</div>
+                        <div class="field">
+                            <input name="syncAvailabilityStatus" type="checkbox" <%= syncAvailabilityStatus ? "checked" : "" %> style="float:left" />
+                        </div>
+                    </li>
+                    <li>
+                        <div class="field">
+                            <p tabIndex="0" class="stepHelp">
+                                This setting enables to reflect the course availability and user enrollment status to access control of Panopto permissions.
+                                <br />
+                                Warning: If this setting is enabled, then the users will lose Panopto permission for unavailable courses or users.
+                                <br/>
+                                <br/>
+                            </p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="label">Email Users</div>
+                        <div class="field">
+                            <input name="mailLectureNotifications" type="checkbox" <%= mailLectureNotifications ? "checked" : "" %> style="float:left" />
+                        </div>
+                    </li>
+                    <li>
+                        <div class="field">
+                            <p tabIndex="0" class="stepHelp">
+                                This setting determines whether an email is automatically sent to users when lectures are processed and ready to view.<br/>
+                                This default may be overridden for individual users via the account settings page in Panopto, after adding a course to Panopto or syncing users.
+                            </p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="label">Refresh Logins</div>
+                        <div class="field">
+                            <input name="refreshLogins" type="checkbox" <%= refreshLogins ? "checked" : "" %> style="float:left" />
+                        </div>
+                    </li>
+                    <li>
+                        <div class="field">
+                            <p tabIndex="0" class="stepHelp">
+                                This setting determines whether to refresh credentials for users logging in from the Panopto Recorder.<br/>
+                                Normally, this should be left checked, so that when one Blackboard user logs out and another logs in,
+                                the Recorder will switch to the new user.<br/>
+                                <br/>
+                                However, if Panopto site cannot redirect to Blackboard SSO page automatically with some reason, 
+                                this behavior may cause unauthenticated users to be prompted to login twice when logging into the Panopto Recorder.<br/>
+                                In this case, disable this setting and instruct your users to exit the Panopto Recorder to complete the logout process.
+                                <br/>
+                                <br/>
+                            </p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="label">Redirect to Blackboard Default Login</div>
+                        <div class="field">
+                            <input name="redirectToDefaultLogin" type="checkbox" <%= redirectToDefaultLogin ? "checked" : "" %> style="float:left" />
+                        </div>
+                    </li>
+                    <li>
+                        <div class="field">
+                            <p tabIndex="0" class="stepHelp">
+                                This setting determines if the SSO forces a redirection to the default login page instead of the relogin URL that was provided. <br />
+                                Enable this feature only if Panopto support advises it. 
                                 <br/>
                                 <br/>
                             </p>
@@ -663,66 +712,23 @@ else
                                 <br/>
                             </p>
                         </div>
-                    </li>
                     <li>
-                        <div class="label">Assign custom role mappings</div>
+                        <div class="label">Max folders per request</div>
                         <div class="field">
-                            <input name="roleMappingString" type="text" size="30" value="<%= roleMappingString %>" style="float:left" />
+                            <input name="maxListedFolders" type="number" min="100" value="<%= maxListedFolders %>" style="float:left" />
                         </div>
                     </li>
                     <li>
                         <div class="field">
                             <p tabIndex="0" class="stepHelp">
-                            Define mappings between custom blackboard roles and the blackboard roles they are recognized by the Panopto block.<br/>
-                            The syntax for mappings is [custom role identifier]:[mapped role name], with each mapping separated by a ';'. <br/>
-                            The available roles to map to are 'instructor', 'ta', and 'none' with any unmapped custom roles being recognized<br/>
-                            as students by the Panopto block. Role specified as 'none' gets no access to the Panopto folder associated with the course.<br/><br/>
-                            
-                            An example mapping string would be: 'custom1:instructor;custom2:ta;custom3:none' (Note: case does not matter)<br/><br/>
-                            
-                            The custom roles available to be mapped are the following:<br/>
-                                <div id = "rolesList">
-                                    <table>
-                                        <tr>
-                                            <th class="customRoleCell">Role Name</th>
-                                            <th class="customRoleCell">Role Identifier</th>
-                                        </tr>
-                                          <% for(Role customRole:customRoles)
-                                            { %>
-                                                <tr>
-                                                    <td class="customRoleCell">
-                                                    <%=customRole.getDbRole().getCourseName()%>
-                                                    </td>
-                                                    <td class = "customRoleCell">
-                                                    <%=customRole.getIdentifier()%>
-                                                    </td>
-                                                </tr>
-                                        <% } %>
-                                    </table>
-                                 </div>   
-                                <br/>
-                                <br/>
-                                <br/>
-                            </p>
-                        </div>
-                    </li>                    
-                    <li>
-                        <div class="label">Blackboard course copy also copies Panopto permissions</div>
-                        <div class="field">
-                            <input name="courseCopyEnabled" type="checkbox" <%= courseCopyEnabled ? "checked" : "" %> style="float:left" />
-                        </div>
-                    </li>
-                    <li>
-                        <div class="field">
-                            <p tabIndex="0" class="stepHelp">
-                                This setting determines whether Panopto permissions are copied along with the course when Blackboard courses are copied.<br/>
-                                <br/>
+                                This setting controls the max number of folders all pages that deal with folders will load.<br/>
+                                It is not recomended to change this setting, increasing this setting may cause timeouts. <br/>
+                                By default this is set to 10000, minimum is 100<br/>
                                 <br/>
                             </p>
                         </div>
                     </li>
                     <li>
-            
 			            <div class="steptitle submittitle" id="steptitle4">
 			                <span id="stepnumber4">4</span>
 			                Done

--- a/WebRoot/WEB-INF/bb-manifest.xml
+++ b/WebRoot/WEB-INF/bb-manifest.xml
@@ -5,7 +5,7 @@
         <description value="Provision Panopto courses from Blackboard.  View live listing of available Panopto content from within the associated Blackboard course.  Import Panopto lecture links as Blackboard content items." />
         <handle value="PanoptoCourseTool" />
         <webapp-type value="javaext" />
-        <version value="2019.4.1" />
+        <version value="2019.11.1" />
         <requires>
             <bbversion value="9.1" />
         </requires>
@@ -64,6 +64,18 @@
                         <icons>
                             <listitem value="images/panopto_logo_50x50.png" />
                         </icons>
+                    </link>
+                </links>
+            </application>
+            <application handle="PanoptoCourseToolAppConfig" type="system" name="Panopto Course Tool Config">
+                <description>Panopto Course Tool Config</description>
+                <links>
+                    <link>
+                        <type value="system_tool" />
+                        <name value="Panopto Tool Settings" />
+                        <url value="Config.jsp" />
+                        <description value="Settings for the Panopto tool" />
+                        <entitlement-uid value="system.panopto.EXECUTE" />
                     </link>
                 </links>
             </application>

--- a/WebRoot/content/mashup.jsp
+++ b/WebRoot/content/mashup.jsp
@@ -38,8 +38,9 @@
     String folderId = "";
     //If course is associated with a single folder, append folder's id to iframe source url
     //This will automatically display course's video's in frame
-    //  If more than one folder is provisioned to a course it will grab the folderId of the first folder with a valid Id.
-    //  If no folders have a valid Id this tool will open to the first folder the user has creator access to, usually thier personal folder.
+    // If the plugin believes no folders are linked to the course it will show an error
+    // If at least one folder is provisioned to the course it will grab the folderId of the first folder it can.
+    // If at least one folder is provisioned to the course but all of them have bad Ids(null, deleted, or corrupted in any way) it will open to the first folder the user has Creator access on.
     if(PanoptoFolders != null){
         int folderCount = Array.getLength(PanoptoFolders);
         if(folderCount >= 1){
@@ -103,38 +104,38 @@
                             selected = false;
                         }
                         //Called when "Insert" is clicked. Creates HTML for embedding each selected video into the editor            
-                            if (message.cmd === 'deliveryList') {       
-                                if(selected){
-                                    var returnString = "",
-                                        PLAYLIST_EMBED_ID = 1,
-                                        VIDEO_EMBED_ID = 0;
-                                    
-                                    // Name the content after the title of the 1st embed, user can edit this later.
-                                    if (message.names && message.names.length > 0) {
-                                        document.getElementById("content_title").value =  message.names[0];
+                        if (message.cmd === 'deliveryList') {       
+                            if(selected){
+                                var returnString = "",
+                                    PLAYLIST_EMBED_ID = 1,
+                                    VIDEO_EMBED_ID = 0;
+                                
+                                // Name the content after the title of the 1st embed, user can edit this later.
+                                if (message.names && message.names.length > 0) {
+                                    document.getElementById("content_title").value =  message.names[0];
+                                }
+                                
+                                //This is going to need to only pass the Id chunks, it looks link BB parses our params and strips out any 'dangerous' html
+                                for (var i = 0; i < message.ids.length; ++ i) {
+                                    var idChunk = '';
+                                    if ((message.playableObjectTypes != null) && (message.playableObjectTypes.size() > i) && (message.playableObjectTypes[i] === PLAYLIST_EMBED_ID)){
+                                        idChunk = "&pid=" + message.ids[i];
+                                    } else {
+                                        idChunk = "&id=" + message.ids[i];
                                     }
                                     
-                                    //This is going to need to only pass the Id chunks, it looks link BB parses our params and strips out any 'dangerous' html
-                                    for (var i = 0; i < message.ids.length; ++ i) {
-                                        var idChunk = '';
-                                        if ((message.playableObjectTypes != null) && (message.playableObjectTypes.size() > i) && (message.playableObjectTypes[i] === PLAYLIST_EMBED_ID)){
-                                            idChunk = "&pid=" + message.ids[i];
-                                        } else {
-                                            idChunk = "&id=" + message.ids[i];
-                                        }
-                                        
-                                        returnString += idChunk;
-                                        if (i < message.ids.length - 1) {
-                                            returnString += ","
-                                        }
-                                    };
-                                    document.getElementById("embed_ids").value =  returnString;
-                                    document.forms["submitForm"].submit();
-                               }
-                               else{
-                                   alert("Please select a video to embed.");
-                               }
+                                    returnString += idChunk;
+                                    if (i < message.ids.length - 1) {
+                                        returnString += ","
+                                    }
+                                };
+                                document.getElementById("embed_ids").value =  returnString;
+                                document.forms["submitForm"].submit();
                            }
+                           else{
+                               alert("Please select a video to embed.");
+                           }
+                       }
                      }, false);
                 }
                 

--- a/WebRoot/vtbe/assignmentMashup.jsp
+++ b/WebRoot/vtbe/assignmentMashup.jsp
@@ -51,12 +51,12 @@ function AlertAndClose(){
                             courseId = "<%=course_id%>",
                             courseKey = "<%=course_key%>",
                             linkChunk = "<%=toolUri%>?view_sandbox=true&course_key=" + courseKey + "&course_id=" + courseId,
-                            step1String = "Prepare your video in Panopto video library. If it's not ready, click <a href='" + linkChunk + "' target='_blank'>here</a> to navigate to your personal folder in Panopto.",
-                            step2String = "Videos are submitted as part of assignments via clicking on \"Write Submission\".",
-                            step3String = "In the text editor expand \"Mashups\" and select \"Panopto Student Video Submission\".",
-                            step4String = "If your submission is not in the default personal folder select the folder where your submission is stored.",
-                            step5String = "Once at the folder your submission is located select the submission and click \"Insert\".",
-                            step6String = "Once your submission has been added to the text editor add any extra information and submit.";
+                            step1String = "Record or upload your video in Panopto. To start creating your video, <a href='" + linkChunk + "' target='_blank'>click here to open your personal folder</a>.",
+                            step2String = "Open the assignment in Blackboard and select <b>Write Submission</b>.",
+                            step3String = "In the text editor, expand <b>Mashups</b> and select <b>Panopto Student Video Submission.</b>",
+                            step4String = "A window will open to show the videos in your personal folder. If your video is located in a different folder, select the correct folder from the drop-down at the top.",
+                            step5String = "Select the video you wish to submit and click <b>Insert.</b>",
+                            step6String = "Your video will be added to the submission. Add any extra information and <b>Submit</b>.";
                         
                         instructions += 
                         "<div>" +

--- a/src/main/com/panopto/blackboard/PanoptoData.java
+++ b/src/main/com/panopto/blackboard/PanoptoData.java
@@ -104,7 +104,7 @@ public class PanoptoData {
     private static final String[] emptyStringArray = new String[0];
 
     // Constants used for paging.
-    private final int maxPages = 100;
+    private int maxPages = 100;
     private final int perPage = 100;
 
     // Blackboard course we are associating with
@@ -181,6 +181,14 @@ public class PanoptoData {
         this.bbUserName = bbUserName;
         this.isInstructor = PanoptoData.isUserInstructor(this.bbCourse.getId(), this.bbUserName, false);
         this.canAddLinks = PanoptoData.canUserAddLinks(this.bbCourse.getId(), this.bbUserName);
+        
+        int maxListedFolders = Integer.parseInt(Utils.pluginSettings.getMaxListedFolders());
+        this.maxPages = (maxListedFolders / this.perPage);
+        
+        // If the user put in a maxListedFolders value that isn't divisible by our pages then add an extra page.
+        if ((maxListedFolders % this.perPage) != 0) {
+            ++this.maxPages;
+        }
         
         // If one is pluginVersion is null set both the plugIn and platform versions.
         if (plugInVersion == null) {

--- a/src/main/com/panopto/blackboard/Settings.java
+++ b/src/main/com/panopto/blackboard/Settings.java
@@ -88,6 +88,8 @@ public class Settings {
     private String menuLinkText = "Panopto Video";
 
     private String roleMappingString = "";
+    
+    private String maxListedFolders = "10000";
 
     /**
      * Boolean setting that turns on copying Panopto permissions during Blackboard course copy
@@ -278,7 +280,15 @@ public class Settings {
         this.roleMappingString = roleMappingString;
         save();
     }
+    
+    public String getMaxListedFolders() {
+        return maxListedFolders;
+    }
 
+    public void setMaxListedFolders(String maxListedFolders) {
+        this.maxListedFolders = maxListedFolders;
+        save();
+    }
     /**
      * Get accessor for the Panopto copy permissions boolean
      * 
@@ -380,6 +390,10 @@ public class Settings {
             Element courseCopyEnabledElem = settingsDocument.createElement("courseCopyEnabled");
             courseCopyEnabledElem.setAttribute("courseCopyEnabled", courseCopyEnabled.toString());
             docElem.appendChild(courseCopyEnabledElem);
+
+            Element maxListedFoldersElem = settingsDocument.createElement("maxListedFolders");
+            maxListedFoldersElem.setAttribute("maxListedFolders", maxListedFolders);
+            docElem.appendChild(maxListedFoldersElem);
 
             File configDir = PlugInUtil.getConfigDirectory(Utils.vendorID, Utils.pluginHandle);
             File settingsFile = new File(configDir, "settings.xml");
@@ -515,6 +529,12 @@ public class Settings {
         if (courseCopyEnabledNodes.getLength() != 0) {
             Element courseCopyEnabledElem = (Element) courseCopyEnabledNodes.item(0);
             this.courseCopyEnabled = Boolean.valueOf(courseCopyEnabledElem.getAttribute("courseCopyEnabled"));
+        }
+
+        NodeList maxListedFoldersNodes = docElem.getElementsByTagName("maxListedFolders");
+        if (maxListedFoldersNodes.getLength() != 0) {
+            Element maxListedFoldersElem = (Element) maxListedFoldersNodes.item(0);
+            this.maxListedFolders = maxListedFoldersElem.getAttribute("maxListedFolders");
         }
     }
 


### PR DESCRIPTION
This plugin fully supports the following Blackboard versions (list updated on 2019-05-10); Blackboard Learn 9.1 Q2 2019 (build 3700), Q4 2018 (build 3500), Q2 2018 (build 3400), Q4 2017 (build 3300), and Blackboard SaaS build 3700.
Note that the support versions may change over the lifetime of this plugin. Please refer this support article for more details.
This plugin does not work with Ultra experience courses on Blackboard SaaS environment.

This version is tested against the release candidate of upcoming Blackboard SaaS 3800 running on OpenJDK 11. All SaaS customers should update to this plugin version before your SaaS site is updated to 3800, otherwise older version of plugin may stop working at that time.

Below is the list of updates from the previous stable release (April 2018 Update 1).
- Updated the instructions in student submission to make them more clear. 
- Added a link to plugin's configuration page in Blackboard's Admin Tools page.
- Added an option to set the maximum number of folders which are listed in the folder selection list for provisioning. The default value is unchanged.
