### PR TITLE
release code for 2020.7.1

### DIFF
--- a/WebRoot/Config.jsp
+++ b/WebRoot/Config.jsp
@@ -75,6 +75,7 @@ Boolean TAsCanCreateLinks = (request.getParameter("TAsCanCreateLinks") != null);
 Boolean courseResetEnabled = (request.getParameter("courseResetEnabled") != null);
 Boolean verbose = (request.getParameter("verbose") != null);
 Boolean insertLinkOnProvision = (request.getParameter("insertLinkOnProvision") != null);
+Boolean videoLinkToolIncludeCreatorFolders = (request.getParameter("videoLinkToolIncludeCreatorFolders") != null);
 String menuLinkText = request.getParameter("menuLinkText");
 String roleMappingString = request.getParameter("roleMappingString");
 Boolean courseCopyEnabled = (request.getParameter("courseCopyEnabled") != null);
@@ -114,6 +115,7 @@ if(instanceName != null)
 	Utils.pluginSettings.setCourseResetEnabled(courseResetEnabled);
 	Utils.pluginSettings.setVerbose(verbose);
 	Utils.pluginSettings.setInsertLinkOnProvision(insertLinkOnProvision);
+	Utils.pluginSettings.setVideoLinkToolIncludeCreatorFolders(videoLinkToolIncludeCreatorFolders);
 	Utils.pluginSettings.setCourseCopyEnabled(courseCopyEnabled);
 	
 	maxListedFolders = (maxListedFolders == null) || maxListedFolders.isEmpty() ? Utils.pluginSettings.getMaxListedFolders() : maxListedFolders;
@@ -153,6 +155,7 @@ TAsCanCreateLinks = Utils.pluginSettings.getTAsCanCreateLinks();
 courseResetEnabled = Utils.pluginSettings.getCourseResetEnabled();
 verbose = Utils.pluginSettings.getVerbose();
 insertLinkOnProvision = Utils.pluginSettings.getInsertLinkOnProvision();
+videoLinkToolIncludeCreatorFolders = Utils.pluginSettings.getVideoLinkToolIncludeCreatorFolders();
 menuLinkText = Utils.pluginSettings.getMenuLinkText();
 roleMappingString = Utils.pluginSettings.getRoleMappingString();
 courseCopyEnabled = Utils.pluginSettings.getCourseCopyEnabled();
@@ -482,6 +485,23 @@ else
                         </div>
                     </li>
                     <li>
+                        <div class="label">Panopto Video Link Tool will include creator folders</div>
+                        <div class="field">
+                            <input name="videoLinkToolIncludeCreatorFolders" type="checkbox"
+                                <%=videoLinkToolIncludeCreatorFolders ? "checked" : ""%>
+                                style="float: left" />
+                        </div>
+                    </li>
+                    <li>
+                        <div class="field">
+                            <p tabIndex="0" class="stepHelp">
+                                When checked, the Panopto Video Link Tool will include folders the user has creator access to in it's list.<br />
+                                Check this if you want to embed videos from sub-folders that are 
+                                inheriting access from mapped folders.<br /> <br />
+                            </p>
+                        </div>
+                    </li>
+                    <li>
                         <div class="label">Panopto Link Text</div>
                         <div class="field">
                             <input name="menuLinkText" type="text" size="30" value="<%= menuLinkText %>" style="float:left" />
@@ -543,7 +563,7 @@ else
                         </div>
                     </li>
                     <li>
-                        <div class="label">Allow TAs to Create Panopto Course Tool Links</div>
+                        <div class="label">Allow TAs to embed with the Panopto Video Link Tool</div>
                         <div class="field">
                             <input name="TAsCanCreateLinks" type="checkbox" <%= TAsCanCreateLinks ? "checked" : "" %> style="float:left" />
                         </div>
@@ -551,8 +571,8 @@ else
                     <li>
                         <div class="field">
                             <p tabIndex="0" class="stepHelp">
-                                This setting determines whether teaching assistants have the ability to create Panopto Course Tool Links on a course's Course Menu.<br/>
-                                 If checked, TAs will be able to create links regardless of whether they have creator access or course provisioning access.              
+                                This setting determines whether teaching assistants have the ability to create Panopto Video Links on a course's content page.<br/>
+                                 If checked, TAs will be able to create video links regardless of whether they have creator access or course provisioning access.              
                                 <br/>
                                 <br/>
                             </p>

--- a/WebRoot/Course_Config.jsp
+++ b/WebRoot/Course_Config.jsp
@@ -124,6 +124,8 @@ if(folderIds != null)
         String provisioningError = ccCourse.getPreviousProvisioningError();
         
         if (!provisioningError.isEmpty()) {
+        	// If the reprovisioning failed and we are in a bad state then re-provision the course with the original folders.
+        	ccCourse.reprovisionCourse();
         %>
         <script>
             if (typeof printPanoptoAlert === "undefined") {

--- a/WebRoot/Item_Create.jsp
+++ b/WebRoot/Item_Create.jsp
@@ -29,6 +29,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 
 <%@taglib uri="/bbUI" prefix="bbUI" %>
+<%@taglib uri="/bbNG" prefix="bbNG" %>
 <%@taglib uri="/bbData" prefix="bbData"%>
 
 <bbUI:coursePage>
@@ -64,11 +65,11 @@ if (!ccCourse.userMayAddLinks())
 {
 %>
 <c:catch>
-	<bbUI:docTemplate title="<%=page_title%>">
-		<bbUI:receipt type="FAIL" iconUrl="<%=iconUrl%>" title="<%=page_title%>" recallUrl="<%=courseDocsURL%>">
+	<bbNG:genericPage title="<%=page_title%>">
+		<bbNG:receipt type="FAIL" iconUrl="<%=iconUrl%>" title="<%=page_title%>" recallUrl="<%=courseDocsURL%>">
 			You do not have access to configure this course. 
-		</bbUI:receipt>
-	</bbUI:docTemplate>
+		</bbNG:receipt>
+	</bbNG:genericPage>
 </c:catch>
 <%
     return;
@@ -81,11 +82,11 @@ if(lectureURL != null)
 	{
 %>
 <c:catch>
-	<bbUI:docTemplate title="<%=page_title%>">
-		<bbUI:receipt type="SUCCESS" iconUrl="<%=iconUrl%>" title="<%=page_title%>" recallUrl="<%=courseDocsURL%>">
+	<bbNG:genericPage title="<%=page_title%>">
+		<bbNG:receipt type="SUCCESS" iconUrl="<%=iconUrl%>" title="<%=page_title%>" recallUrl="<%=courseDocsURL%>">
 			Item created.
-		</bbUI:receipt>
-	</bbUI:docTemplate>
+		</bbNG:receipt>
+	</bbNG:genericPage>
 </c:catch>
 <%
     }
@@ -93,33 +94,33 @@ if(lectureURL != null)
     {
 %>
     <c:catch>
-        <bbUI:docTemplate title="<%=page_title%>">
-            <bbUI:receipt type="FAILURE" iconUrl="<%=iconUrl%>" title="<%=page_title%>" recallUrl="<%=courseDocsURL%>">
+        <bbNG:genericPage title="<%=page_title%>">
+            <bbNG:receipt type="FAILURE" iconUrl="<%=iconUrl%>" title="<%=page_title%>" recallUrl="<%=courseDocsURL%>">
                 <font color = "red">The session cannot be added. Please have the creator approve the session in Panopto and then add the session.</font>
-            </bbUI:receipt>
-        </bbUI:docTemplate>
+            </bbNG:receipt>
+        </bbNG:genericPage>
     </c:catch><%
         }
         else if(linkCreationOutput.equals(PanoptoData.LinkAddedResult.NOTPUBLISHER))
         {
     %>
     <c:catch>
-        <bbUI:docTemplate title="<%=page_title%>">
-            <bbUI:receipt type="FAILURE" iconUrl="<%=iconUrl%>" title="<%=page_title%>" recallUrl="<%=courseDocsURL%>">
+        <bbNG:genericPage title="<%=page_title%>">
+            <bbNG:receipt type="FAILURE" iconUrl="<%=iconUrl%>" title="<%=page_title%>" recallUrl="<%=courseDocsURL%>">
                 <font color = "red">The session cannot be added. Please have the publisher make the session available in Panopto and then add the session.</font>
-            </bbUI:receipt>
-        </bbUI:docTemplate>
+            </bbNG:receipt>
+        </bbNG:genericPage>
     </c:catch><%
     }
     else
     {
     %>
     <c:catch>
-        <bbUI:docTemplate title="<%=page_title%>">
-            <bbUI:receipt type="FAILURE" iconUrl="<%=iconUrl%>" title="<%=page_title%>" recallUrl="<%=courseDocsURL%>">
+        <bbNG:genericPage title="<%=page_title%>">
+            <bbNG:receipt type="FAILURE" iconUrl="<%=iconUrl%>" title="<%=page_title%>" recallUrl="<%=courseDocsURL%>">
                 <font color = "red">The session could not be added to the course. See logs for details.</font>
-            </bbUI:receipt>
-        </bbUI:docTemplate>
+            </bbNG:receipt>
+        </bbNG:genericPage>
     </c:catch><%
     }
 	return;
@@ -127,18 +128,18 @@ if(lectureURL != null)
 }
 %>
 
-	<bbUI:docTemplate title="<%=page_title%>">
+	<bbNG:genericPage title="<%=page_title%>">
 
-		<bbUI:docTemplateHead>
+		<bbNG:pageHeader>
+			<c:catch>
+				<bbNG:pageTitleBar iconUrl="<%=iconUrl%>">
+					<%=page_title%>
+				</bbNG:pageTitleBar>
+			</c:catch>
 			<link rel="stylesheet" type="text/css" href="css/main.css" />
-		</bbUI:docTemplateHead>
+		</bbNG:pageHeader>
 
 		<bbUI:coursePage courseId="<%= ctx.getCourseId() %>">
-		<c:catch>
-			<bbUI:titleBar iconUrl="<%=iconUrl%>">
-				<%=page_title%>
-			</bbUI:titleBar>
-		</c:catch>
 
 			<% 
 			if (!ccCourse.isMapped())
@@ -273,7 +274,7 @@ if(lectureURL != null)
 	
 		</bbUI:coursePage>
 
-	</bbUI:docTemplate>
+	</bbNG:genericPage>
 
 </bbData:context>
 </bbUI:coursePage>

--- a/WebRoot/WEB-INF/bb-manifest.xml
+++ b/WebRoot/WEB-INF/bb-manifest.xml
@@ -5,7 +5,7 @@
         <description value="Provision Panopto courses from Blackboard.  View live listing of available Panopto content from within the associated Blackboard course.  Import Panopto lecture links as Blackboard content items." />
         <handle value="PanoptoCourseTool" />
         <webapp-type value="javaext" />
-        <version value="2020.6.1" />
+        <version value="2020.7.1" />
         <requires>
             <bbversion value="9.1" />
         </requires>

--- a/src/main/com/panopto/blackboard/Settings.java
+++ b/src/main/com/panopto/blackboard/Settings.java
@@ -84,6 +84,9 @@ public class Settings {
     // Insert a link to panopto tool on course page when a course is provisioned
     private Boolean insertLinkOnProvision = false;
 
+    // Whether or not the Panopto Link tool uses Mapped + Public or Mapped + Creator folders. 
+    private Boolean videoLinkToolIncludeCreatorFolders = false;
+
     // Text for link created on provision. Default is "Panopto Video"
     private String menuLinkText = "Panopto Video";
 
@@ -223,7 +226,7 @@ public class Settings {
     }
 
     public void setRedirectToDefaultLogin(boolean useDefaultLogin) {
-    	redirectToDefaultLogin = useDefaultLogin;
+        redirectToDefaultLogin = useDefaultLogin;
         save();
     }
 
@@ -260,6 +263,15 @@ public class Settings {
 
     public void setInsertLinkOnProvision(Boolean insertLinkOnProvision) {
         this.insertLinkOnProvision = insertLinkOnProvision;
+        save();
+    }
+
+    public Boolean getVideoLinkToolIncludeCreatorFolders() {
+        return videoLinkToolIncludeCreatorFolders;
+    }
+
+    public void setVideoLinkToolIncludeCreatorFolders(Boolean videoLinkToolIncludeCreatorFolders) {
+        this.videoLinkToolIncludeCreatorFolders = videoLinkToolIncludeCreatorFolders;
         save();
     }
 
@@ -378,6 +390,10 @@ public class Settings {
             Element insertLinkOnProvisionElem = settingsDocument.createElement("insertLinkOnProvision");
             insertLinkOnProvisionElem.setAttribute("insertLinkOnProvision", insertLinkOnProvision.toString());
             docElem.appendChild(insertLinkOnProvisionElem);
+
+            Element videoLinkToolIncludeCreatorFoldersElem = settingsDocument.createElement("videoLinkToolIncludeCreatorFolders");
+            videoLinkToolIncludeCreatorFoldersElem.setAttribute("videoLinkToolIncludeCreatorFolders", videoLinkToolIncludeCreatorFolders.toString());
+            docElem.appendChild(videoLinkToolIncludeCreatorFoldersElem);
 
             Element menuLinkTextElem = settingsDocument.createElement("menuLinkText");
             menuLinkTextElem.setAttribute("menutext", menuLinkText);
@@ -511,6 +527,13 @@ public class Settings {
             Element insertLinkOnProvisionElem = (Element) insertLinkOnProvisionNodes.item(0);
             this.insertLinkOnProvision = Boolean
                     .valueOf(insertLinkOnProvisionElem.getAttribute("insertLinkOnProvision"));
+        }
+
+        NodeList videoLinkToolIncludeCreatorFoldersNodes = docElem.getElementsByTagName("videoLinkToolIncludeCreatorFolders");
+        if (videoLinkToolIncludeCreatorFoldersNodes.getLength() != 0) {
+            Element videoLinkToolIncludeCreatorFoldersElem = (Element) videoLinkToolIncludeCreatorFoldersNodes.item(0);
+            this.videoLinkToolIncludeCreatorFolders = Boolean
+                    .valueOf(videoLinkToolIncludeCreatorFoldersElem.getAttribute("videoLinkToolIncludeCreatorFolders"));
         }
 
         NodeList menuLinkTextNodes = docElem.getElementsByTagName("menuLinkText");


### PR DESCRIPTION
This plugin fully supports Blackboard SaaS build 3800.11 and later (including upcoming 3800.13). THIS DOES NOT SUPPORT ANY VERSION OF Blackboard Self- or Managed-Hosting servers.
Note that the support versions may change over the lifetime of this plugin. Please [refer this support article](https://support.panopto.com/s/article/Panopto-Blackboard-Integration-Support-Policy) for more details.
This plugin does not work with Ultra experience courses on Blackboard SaaS environment.

Below is the list of updates from the previous stable release (June 2020 Update 1).
- Fixed an issue with the latest plugin (2020.6.1) that prevented users from mapping multiple folders to a course.
- Fixed an issue where Resetting a course would consider the reset successful even if the course remained provisioned in Panopto.
- Replaced ‘Allow TAs to Create Panopto Course Tool Links’ with ‘Allow TAs to embed with Panopto Video Link Tool’ to more accurately describe what the toggle does.
- Fixed an issue where the Panopto Video Link tool would break the Blackboard user interface to navigate out of a course after inserting a link.
- Added a toggle that enabled all folders that an instructor had creator access to be listed in the Panopto Video Link tool in addition to the mapped and public folders.
- Fixed an issue where the Panopto Video Link tool did not properly show public folders.
- Fixed an issue that could leave a course provisioned incorrectly if a user tried to map an invalid folder to an already provisioned course. This case will now result in the course being put back to its original state, before attempting to add the invalid folder.
