### PR TITLE
SH-2020.8.1 release code

### DIFF
--- a/WebRoot/Config.jsp
+++ b/WebRoot/Config.jsp
@@ -75,6 +75,7 @@ Boolean TAsCanCreateLinks = (request.getParameter("TAsCanCreateLinks") != null);
 Boolean courseResetEnabled = (request.getParameter("courseResetEnabled") != null);
 Boolean verbose = (request.getParameter("verbose") != null);
 Boolean insertLinkOnProvision = (request.getParameter("insertLinkOnProvision") != null);
+Boolean videoLinkToolIncludeCreatorFolders = (request.getParameter("videoLinkToolIncludeCreatorFolders") != null);
 String menuLinkText = request.getParameter("menuLinkText");
 String roleMappingString = request.getParameter("roleMappingString");
 Boolean courseCopyEnabled = (request.getParameter("courseCopyEnabled") != null);
@@ -114,6 +115,7 @@ if(instanceName != null)
 	Utils.pluginSettings.setCourseResetEnabled(courseResetEnabled);
 	Utils.pluginSettings.setVerbose(verbose);
 	Utils.pluginSettings.setInsertLinkOnProvision(insertLinkOnProvision);
+	Utils.pluginSettings.setVideoLinkToolIncludeCreatorFolders(videoLinkToolIncludeCreatorFolders);
 	Utils.pluginSettings.setCourseCopyEnabled(courseCopyEnabled);
 	
 	maxListedFolders = (maxListedFolders == null) || maxListedFolders.isEmpty() ? Utils.pluginSettings.getMaxListedFolders() : maxListedFolders;
@@ -153,6 +155,7 @@ TAsCanCreateLinks = Utils.pluginSettings.getTAsCanCreateLinks();
 courseResetEnabled = Utils.pluginSettings.getCourseResetEnabled();
 verbose = Utils.pluginSettings.getVerbose();
 insertLinkOnProvision = Utils.pluginSettings.getInsertLinkOnProvision();
+videoLinkToolIncludeCreatorFolders = Utils.pluginSettings.getVideoLinkToolIncludeCreatorFolders();
 menuLinkText = Utils.pluginSettings.getMenuLinkText();
 roleMappingString = Utils.pluginSettings.getRoleMappingString();
 courseCopyEnabled = Utils.pluginSettings.getCourseCopyEnabled();
@@ -482,6 +485,23 @@ else
                         </div>
                     </li>
                     <li>
+                        <div class="label">Panopto Video Link Tool will include creator folders</div>
+                        <div class="field">
+                            <input name="videoLinkToolIncludeCreatorFolders" type="checkbox"
+                                <%=videoLinkToolIncludeCreatorFolders ? "checked" : ""%>
+                                style="float: left" />
+                        </div>
+                    </li>
+                    <li>
+                        <div class="field">
+                            <p tabIndex="0" class="stepHelp">
+                                When checked, the Panopto Video Link Tool will include folders the user has creator access to in it's list.<br />
+                                Check this if you want to embed videos from sub-folders that are 
+                                inheriting access from mapped folders.<br /> <br />
+                            </p>
+                        </div>
+                    </li>
+                    <li>
                         <div class="label">Panopto Link Text</div>
                         <div class="field">
                             <input name="menuLinkText" type="text" size="30" value="<%= menuLinkText %>" style="float:left" />
@@ -543,7 +563,7 @@ else
                         </div>
                     </li>
                     <li>
-                        <div class="label">Allow TAs to Create Panopto Course Tool Links</div>
+                        <div class="label">Allow TAs to embed with the Panopto Video Link Tool</div>
                         <div class="field">
                             <input name="TAsCanCreateLinks" type="checkbox" <%= TAsCanCreateLinks ? "checked" : "" %> style="float:left" />
                         </div>
@@ -551,8 +571,8 @@ else
                     <li>
                         <div class="field">
                             <p tabIndex="0" class="stepHelp">
-                                This setting determines whether teaching assistants have the ability to create Panopto Course Tool Links on a course's Course Menu.<br/>
-                                 If checked, TAs will be able to create links regardless of whether they have creator access or course provisioning access.              
+                                This setting determines whether teaching assistants have the ability to create Panopto Video Links on a course's content page.<br/>
+                                 If checked, TAs will be able to create video links regardless of whether they have creator access or course provisioning access.              
                                 <br/>
                                 <br/>
                             </p>

--- a/WebRoot/Course_Config.jsp
+++ b/WebRoot/Course_Config.jsp
@@ -124,6 +124,8 @@ if(folderIds != null)
         String provisioningError = ccCourse.getPreviousProvisioningError();
         
         if (!provisioningError.isEmpty()) {
+			// If the reprovisioning failed and we are in a bad state then re-provision the course with the original folders.
+			ccCourse.reprovisionCourse();
         %>
         <script>
             if (typeof printPanoptoAlert === "undefined") {

--- a/WebRoot/WEB-INF/bb-manifest.xml
+++ b/WebRoot/WEB-INF/bb-manifest.xml
@@ -5,7 +5,7 @@
         <description value="Provision Panopto courses from Blackboard.  View live listing of available Panopto content from within the associated Blackboard course.  Import Panopto lecture links as Blackboard content items." />
         <handle value="PanoptoCourseTool" />
         <webapp-type value="javaext" />
-        <version value="2019.11.1" />
+        <version value="2020.8.1" />
         <requires>
             <bbversion value="9.1" />
         </requires>

--- a/src/main/com/panopto/blackboard/Settings.java
+++ b/src/main/com/panopto/blackboard/Settings.java
@@ -84,6 +84,9 @@ public class Settings {
     // Insert a link to panopto tool on course page when a course is provisioned
     private Boolean insertLinkOnProvision = false;
 
+    // Whether or not the Panopto Link tool uses Mapped + Public or Mapped + Creator folders. 
+    private Boolean videoLinkToolIncludeCreatorFolders = false;
+    
     // Text for link created on provision. Default is "Panopto Video"
     private String menuLinkText = "Panopto Video";
 
@@ -223,7 +226,7 @@ public class Settings {
     }
 
     public void setRedirectToDefaultLogin(boolean useDefaultLogin) {
-    	redirectToDefaultLogin = useDefaultLogin;
+        redirectToDefaultLogin = useDefaultLogin;
         save();
     }
 
@@ -263,6 +266,15 @@ public class Settings {
         save();
     }
 
+    public Boolean getVideoLinkToolIncludeCreatorFolders() {
+        return videoLinkToolIncludeCreatorFolders;
+    }
+
+    public void setVideoLinkToolIncludeCreatorFolders(Boolean videoLinkToolIncludeCreatorFolders) {
+        this.videoLinkToolIncludeCreatorFolders = videoLinkToolIncludeCreatorFolders;
+        save();
+    }
+    
     public String getMenuLinkText() {
         return menuLinkText;
     }
@@ -379,6 +391,10 @@ public class Settings {
             insertLinkOnProvisionElem.setAttribute("insertLinkOnProvision", insertLinkOnProvision.toString());
             docElem.appendChild(insertLinkOnProvisionElem);
 
+            Element videoLinkToolIncludeCreatorFoldersElem = settingsDocument.createElement("videoLinkToolIncludeCreatorFolders");
+            videoLinkToolIncludeCreatorFoldersElem.setAttribute("videoLinkToolIncludeCreatorFolders", videoLinkToolIncludeCreatorFolders.toString());
+            docElem.appendChild(videoLinkToolIncludeCreatorFoldersElem);
+            
             Element menuLinkTextElem = settingsDocument.createElement("menuLinkText");
             menuLinkTextElem.setAttribute("menutext", menuLinkText);
             docElem.appendChild(menuLinkTextElem);
@@ -513,6 +529,13 @@ public class Settings {
                     .valueOf(insertLinkOnProvisionElem.getAttribute("insertLinkOnProvision"));
         }
 
+        NodeList videoLinkToolIncludeCreatorFoldersNodes = docElem.getElementsByTagName("videoLinkToolIncludeCreatorFolders");
+        if (videoLinkToolIncludeCreatorFoldersNodes.getLength() != 0) {
+            Element videoLinkToolIncludeCreatorFoldersElem = (Element) videoLinkToolIncludeCreatorFoldersNodes.item(0);
+            this.videoLinkToolIncludeCreatorFolders = Boolean
+                    .valueOf(videoLinkToolIncludeCreatorFoldersElem.getAttribute("videoLinkToolIncludeCreatorFolders"));
+        }
+        
         NodeList menuLinkTextNodes = docElem.getElementsByTagName("menuLinkText");
         if (menuLinkTextNodes.getLength() != 0) {
             Element menuLinkTextElem = (Element) menuLinkTextNodes.item(0);


### PR DESCRIPTION
This plugin fully supports Blackboard Learn 9.1 Q4 2019 (build 3800). THIS DOES NOT SUPPORT ANY Blackboard SaaS versions. Please use the [[SaaS customers only] Blackboard Plugin July 2020 Update 1](https://github.com/Panopto/Blackboard-9.1-Plugin-for-Panopto/releases/tag/2020.7.1) plugin version for Blackboard SaaS.
Note that the support versions may change over the lifetime of this plugin. Please [refer this support article](https://support.panopto.com/s/article/Panopto-Blackboard-Integration-Support-Policy) for more details.
This plugin does not work with Ultra experience courses on Blackboard SaaS environment.

Below is the list of updates from the previous stable release (November 2019 Update 1).
- Fixed an issue where Resetting a course would consider the reset successful even if the course remained provisioned in Panopto.
- Replaced ‘Allow TAs to Create Panopto Course Tool Links’ with ‘Allow TAs to embed with the Panopto Video Link Tool’ to more accurately describe what the toggle does.
- Added a toggle that enabled all folders that an instructor had creator access to be listed in the Panopto Video Link tool in addition to the mapped and public folders.
- Fixed an issue where the Panopto Video Link tool did not properly show public folders.
- Fixed an issue that could leave a course provisioned incorrectly if a user tried to map an invalid folder to an already provisioned course. This case will now result in the course being put back to its original state, before attempting to add the invalid folder.
