### PR TITLE
2020.9.2 release code.

### DIFF
--- a/WebRoot/WEB-INF/bb-manifest.xml
+++ b/WebRoot/WEB-INF/bb-manifest.xml
@@ -5,7 +5,7 @@
         <description value="Provision Panopto courses from Blackboard.  View live listing of available Panopto content from within the associated Blackboard course.  Import Panopto lecture links as Blackboard content items." />
         <handle value="PanoptoCourseTool" />
         <webapp-type value="javaext" />
-        <version value="2020.8.1" />
+        <version value="2020.9.2" />
         <requires>
             <bbversion value="9.1" />
         </requires>


### PR DESCRIPTION
[SaaS customers only][Beta] Blackboard Plugin September 2020 Update 2

This plugin fully supports Blackboard SaaS build 3800.17.0 and later. THIS DOES NOT SUPPORT ANY VERSION OF Blackboard Self- or Managed-Hosting servers.
This plugin does not work with Ultra experience courses on Blackboard SaaS environment.

This is the latest beta release of the Panopto plug-in for Blackboard, and this is exactly the  same version as August 2020 Update 1 release (2020.8.1), but with a newer version number. Use this beta version if you currently use 2020.8.2 or you are going to integrate Panopto for the first time.
