### PR TITLE
code for 2020.12.2 release.

### DIFF
--- a/WebRoot/WEB-INF/bb-manifest.xml
+++ b/WebRoot/WEB-INF/bb-manifest.xml
@@ -5,7 +5,7 @@
         <description value="Provision Panopto courses from Blackboard.  View live listing of available Panopto content from within the associated Blackboard course.  Import Panopto lecture links as Blackboard content items." />
         <handle value="PanoptoCourseTool" />
         <webapp-type value="javaext" />
-        <version value="2020.12.1" />
+        <version value="2020.12.2" />
         <requires>
             <bbversion value="9.1" />
         </requires>

--- a/WebRoot/vtbe/assignmentMashup.jsp
+++ b/WebRoot/vtbe/assignmentMashup.jsp
@@ -61,12 +61,12 @@ function AlertAndClose(){
                             courseKey = "<%=course_key%>",
                             serverName = "<%=serverName%>",
                             linkChunk = "<%=toolUri%>?view_sandbox=true&course_key=" + courseKey + "&course_id=" + courseId,
-                            step1String = "Record or upload your video in Panopto. To start creating your video, open your <a href='" + linkChunk + "' target='_blank'>Panopto video library.</a>.",
+                            step1String = "Record or upload your video in Panopto. To start creating your video, open your <a href='" + linkChunk + "' target='_blank'>Panopto video library</a>.",
                             step2String = "Open the assignment in Blackboard and select <b>Write Submission</b>.",
                             step3OldEditorString = "In the text editor, expand <b>Mashups</b> and select <b>Panopto Student Video Submission</b>.",
                             step3NewEditorString = "In the text editor, select the three dots to expand the entire toolbar, and then select the icon, which looks like a circle with a plus symbol inside of it, to open the Add Content window. Then select <b>Panopto Student Video Submission</b>.",
                             step4String = "A window will open to show the videos in your personal folder. If your video is located in a different folder, select the correct folder from the drop-down at the top.",
-                            step5String = "Select the video you wish to submit and click <b>Insert.</b>",
+                            step5String = "Select the video you wish to submit and click <b>Submit Video</b>.",
                             step6String = "Your video will be added to the submission. Add any extra information and <b>Submit</b>.";
                         
                         if (serverName) {


### PR DESCRIPTION
This is the latest optional release of the Panopto plugin for Blackboard, this update is recommended to any customers experiencing trouble with the below issue.

This plugin fully supports Blackboard Learn 9.1 3900, Q4 2019 (build 3800), and Blackboard SaaS build 3900.
This plugin does not work with Ultra experience courses on Blackboard SaaS environments.
Note that the support versions may change over the lifetime of this plugin. Please [refer to this support article](https://support.panopto.com/s/article/Panopto-Blackboard-Integration-Support-Policy) for more details.

- Fixed an issue where there was an inaccurate button label being listed in the student submission instructions. This would cause users to look for a button labeled 'insert' instead of 'Submit Video'.
