### PR TITLE
code for release.

### DIFF
--- a/WebRoot/Config.jsp
+++ b/WebRoot/Config.jsp
@@ -207,7 +207,7 @@ if(serverList == null)
 }
 else
 {
-    String provisionServerName = defaultPanoptoServer;
+    String defaultProvisionServerName = defaultPanoptoServer;
 %>
     <bbUI:titleBar iconUrl="<%=iconUrl%>">
         <%=page_title%>
@@ -356,8 +356,8 @@ else
                             Server 
                         </div>
                         <div class="field">
-                            <select name="panoptoServerName" <%=((serverList.size() == 1) ? "DISABLED='disabled'" : "")%>>
-                                <%= Utils.generateServerOptionsHTML(provisionServerName) %>
+                            <select name="provisionServerName" <%=((serverList.size() == 1) ? "DISABLED='disabled'" : "")%>>
+                                <%= Utils.generateServerOptionsHTML(defaultProvisionServerName) %>
                             </select>
                         </div>
                     </li>

--- a/WebRoot/WEB-INF/bb-manifest.xml
+++ b/WebRoot/WEB-INF/bb-manifest.xml
@@ -5,7 +5,7 @@
         <description value="Provision Panopto courses from Blackboard.  View live listing of available Panopto content from within the associated Blackboard course.  Import Panopto lecture links as Blackboard content items." />
         <handle value="PanoptoCourseTool" />
         <webapp-type value="javaext" />
-        <version value="2020.12.2" />
+        <version value="2021.1.1" />
         <requires>
             <bbversion value="9.1" />
         </requires>


### PR DESCRIPTION
This is the latest optional release of the Panopto plugin for Blackboard, this update is recommended to any customers experiencing trouble with the below issue.

This plugin fully supports Blackboard Learn 9.1 3900, Q4 2019 (build 3800), and Blackboard SaaS build 3900.

This plugin does not work with Ultra experience courses on Blackboard SaaS environments.

Note that the support versions may change over the lifetime of this plugin. Please [refer to this support article](https://support.panopto.com/s/article/Panopto-Blackboard-Integration-Support-Policy) for more details.

- Fixed a bug introduced in version 2012.12.1 that would block bulk provisioning of courses from the Panopto Connector Building Block settings page if a Blackboard server was connected to multiple Panopto servers.
