### PR TITLE
2021.12.1 release code

### DIFF
--- a/WebRoot/Course_Config.jsp
+++ b/WebRoot/Course_Config.jsp
@@ -109,7 +109,12 @@ if(folderIds != null)
     
     // Since we are reconfiguring a course we should reset the existing context and assignment folders so new ones can be made.
     // Only redirect if the provisioning all succeeded, otherwise keep the user there and display the error.
-    ccCourse.unprovisionExternalCourse();
+    
+    String[] currentFolderIds = ccCourse.getSessionGroupPublicIDs();
+    
+    if (!folderIds.equals(currentFolderIds)) {
+        ccCourse.unprovisionExternalCourse();
+    }
     
     if(ccCourse.reprovisionCourse(folderIds)) {
         ccCourse.updateFolderExternalIdWithProvider(folderIds[0]);

--- a/WebRoot/WEB-INF/bb-manifest.xml
+++ b/WebRoot/WEB-INF/bb-manifest.xml
@@ -5,7 +5,7 @@
         <description value="Provision Panopto courses from Blackboard.  View live listing of available Panopto content from within the associated Blackboard course.  Import Panopto lecture links as Blackboard content items." />
         <handle value="PanoptoCourseTool" />
         <webapp-type value="javaext" />
-        <version value="2021.6.1" />
+        <version value="2021.12.1" />
         <requires>
             <bbversion value="9.1" />
         </requires>

--- a/WebRoot/content/mashup.jsp
+++ b/WebRoot/content/mashup.jsp
@@ -166,7 +166,7 @@
                        <iframe id="pageframe" width="100%" height="100%" src="<%=IFrameSrc%>"></iframe>
                    </div>
             </bbNG:step>
-            <bbNG:stepSubmit showCancelButton="true">
+            <bbNG:stepSubmit>
                  <bbNG:stepSubmitButton id="submitbutton" label="Insert Video" onClick="clickSubmit()"/>
             </bbNG:stepSubmit>            
         </bbNG:dataCollection>

--- a/WebRoot/vtbe/assignmentMashup.jsp
+++ b/WebRoot/vtbe/assignmentMashup.jsp
@@ -179,7 +179,7 @@
 	                        <iframe id="pageframe" width="100%" height="100%" src="<%=activeFrameSrc%>"></iframe>
 	                    </div>
 	                </bbNG:step>
-	                <bbNG:stepSubmit showCancelButton="true" cancelOnClick="self.close();">
+	                <bbNG:stepSubmit>
 	                     <bbNG:stepSubmitButton id="submitbutton" label="Submit Video" onClick="clickSubmit()"/>
 	                </bbNG:stepSubmit>
 	            </bbNG:dataCollection>

--- a/WebRoot/vtbe/mashup.jsp
+++ b/WebRoot/vtbe/mashup.jsp
@@ -125,7 +125,7 @@ function AlertAndClose(){
                         <iframe id="pageframe" width="100%" height="100%" src="<%=IFrameSrc%>"></iframe>
                     </div>
                 </bbNG:step>
-                <bbNG:stepSubmit showCancelButton="true" cancelOnClick="self.close();">
+                <bbNG:stepSubmit>
                      <bbNG:stepSubmitButton id="submitbutton" label="Insert Videos" onClick="clickSubmit()"/>
                 </bbNG:stepSubmit>
             </bbNG:dataCollection>

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 		    <artifactId>httpclient</artifactId>
-		    <version>4.5.3</version>
+		    <version>4.5.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>

--- a/src/main/com/panopto/blackboard/PanoptoData.java
+++ b/src/main/com/panopto/blackboard/PanoptoData.java
@@ -167,6 +167,11 @@ public class PanoptoData {
         return previousProvisioningError;
     }
     
+    // Returns the Ids of folders currently mapped to the course. 
+    public String[] getSessionGroupPublicIDs() {
+        return sessionGroupPublicIDs;
+    }
+    
     // SOAP port for talking to Panopto
     private SessionManagementStub sessionManagement;
 


### PR DESCRIPTION
This is the latest stable release of the Panopto plugin for Blackboard, which is recommended to all customers.

This plugin fully supports Blackboard Learn 9.1 3900, Q4 2019 (build 3800), and Blackboard SaaS.

This plugin does not work with Ultra experience courses on Blackboard SaaS environments.

Note that the support versions may change over the lifetime of this plugin. Please refer to [this support article](https://support.panopto.com/s/article/Panopto-Blackboard-Integration-Support-Policy) for more details.
- Removed a non-functional “Cancel” button when using the Panopto Video Mashups tool
- Updated a dependency to improve security
