### PR TITLE
2022.12.1 release code

### DIFF
--- a/WebRoot/Bulk_Reset.jsp
+++ b/WebRoot/Bulk_Reset.jsp
@@ -1,0 +1,93 @@
+<!-- Copyright Panopto 2009 - 2016
+ * 
+ * This file is part of the Panopto plugin for Blackboard.
+ * 
+ * The Panopto plugin for Blackboard is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Panopto plugin for Blackboard is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Panopto plugin for Blackboard.  If not, see <http://www.gnu.org/licenses/>.
+ */ -->
+
+<%@page import="java.util.Arrays"%>
+<%@page language="java" pageEncoding="ISO-8859-1" %>
+
+<%@page import="com.panopto.blackboard.Utils"%>
+<%@page import="com.panopto.blackboard.PanoptoCourseSearch"%>
+<%@page import="blackboard.data.course.Course"%>
+<%@page import="java.util.List"%>
+<%@page import="java.util.ArrayList"%>
+<%@page import="com.panopto.blackboard.PanoptoData"%>
+<%@page import="com.panopto.services.*"%>
+
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+
+<%@taglib uri="/bbUI" prefix="bbUI" %>
+<%@taglib uri="/bbData" prefix="bbData"%>
+
+<%
+String iconUrl = "/images/ci/icons/bookopen_u.gif";
+String page_title = "Bulk Reset Panopto Courses";
+
+String returnUrl = request.getParameter("returnUrl");
+%>
+<bbUI:coursePage>
+    <bbData:context id="ctx">
+        <bbUI:docTemplate title="<%=page_title%>">
+        <c:catch>
+            <bbUI:docTemplateHead>
+                <link rel="stylesheet" type="text/css" href="css/main.css" />
+            </bbUI:docTemplateHead>
+
+            <bbUI:titleBar iconUrl="<%=iconUrl%>">
+                <%=page_title%>
+            </bbUI:titleBar>
+        </c:catch>
+<%
+
+if (!Utils.userCanConfigureSystem())
+{
+    %><div class='error'>Error. You do not have access to reset all courses.</div><%
+}
+else
+{
+    %>
+            <div id='bulkResetResultsHeader'>Reset Results:</div>
+            <div id='bulkResetResults'>
+    <%
+    
+    java.util.List<Course> allCourses = PanoptoCourseSearch.GetAllCourses();
+    if (allCourses.size() == 0)
+    {
+        %><div class='errorMessage'>Unable to retrieve Blackboard courses</div><%
+    }
+    
+    for (Course course : allCourses)
+    {
+        if (PanoptoData.HasPanoptoServer(course))
+        {
+            PanoptoData ccCourse = new PanoptoData(course, ctx.getUser().getUserName());
+            
+            ccCourse.resetCourse(false);
+            %><div class='successMessage'>Reset course <%= ccCourse.getBBCourse().getCourseId() %>: <%= ccCourse.getBBCourse().getTitle() %></div><%
+        }
+    }
+
+    %>
+            </div>
+    <%  
+}
+ %>
+        <div>
+            <bbUI:button type="INLINE" name="OK" alt="OK" action="LINK" targetUrl="<%=returnUrl%>" />
+        </div>
+        </bbUI:docTemplate>
+    </bbData:context>
+</bbUI:coursePage>

--- a/WebRoot/Config.jsp
+++ b/WebRoot/Config.jsp
@@ -21,6 +21,8 @@
 
 <%@page import="com.panopto.blackboard.Utils"%>
 <%@page import="java.util.*"%>
+<%@page import="java.net.URL"%>
+<%@page import="java.net.MalformedURLException"%>
 <%@page import="blackboard.platform.plugin.PlugInUtil" %>
 <%@page import="blackboard.data.course.CourseMembership" %>
 <%@page import="blackboard.data.course.CourseMembership.Role" %>
@@ -86,6 +88,7 @@ String maxSocketWait = request.getParameter("maxSocketWait");
 
 //Bounce page address to copy into Panopto
 String SSOAddress = "https://" + ctx.getHostName()  + PlugInUtil.getUri("ppto", "PanoptoCourseTool", "SSO.jsp");
+String LogsAddress = "https://" + ctx.getHostName()  + PlugInUtil.getUri("ppto", "PanoptoCourseTool", "Logs.jsp");
 
 //Array of all course membership roles to list.
 Role[] courseRoles = CourseMembership.Role.getAllCourseRoles();
@@ -184,8 +187,16 @@ if((remove_hostname != null) && !remove_hostname.equals(""))
 }
 if((add_hostname != null) && (add_hostname_key != null))
 {
-    add_hostname = add_hostname.trim();
+    String originalHostname = add_hostname.toLowerCase().trim();
+    add_hostname = originalHostname;
     add_hostname_key = add_hostname_key.trim();
+    
+    try {
+        URL url = new URL(add_hostname);
+        add_hostname = url.getAuthority() + url.getPath();
+    } catch (MalformedURLException e) {
+        Utils.log("New Panopto server URL, " + originalHostname + ", is invalid. Please input a proper FQDN, e.g. myinstitution.region.panopto.com");
+    }
     
     if(!add_hostname.equals("") && !add_hostname_key.equals(""))
     {
@@ -266,7 +277,7 @@ else
                                     <tr>
                                         <td>
                                             <input name="add_hostname" size="30" value="" />
-                                            <div class="settingNote">e.g. panopto.myinstitution.edu</div>
+                                            <div class="settingNote">e.g. myinstitution.region.panopto.com</div>
                                         </td>
                                         <td>
                                             <input name="add_hostname_key" size="40" value="" />
@@ -278,7 +289,6 @@ else
                                     </tr>
                                 </table>
                             </div>
-
                         </div>
                     </li>
                 </ol>
@@ -435,6 +445,30 @@ else
                     <%
                     }
                     %>
+                </ol>
+            </div>
+          </div>
+    </form>
+    
+    <!-- Post to breakout bulk reset page. -->
+    <form name="bulkResetForm" action="Bulk_Reset.jsp" method="post">
+         <div class="form">
+            <div class="steptitle submittitle" id="steptitle2">
+                <span id="stepnumber2">2</span>
+                Reset All Provisioned courses
+            </div>
+            <div class="stepcontent" id="step2">
+                <ol>
+                    <li><!-- URL of current page so provision breakout page knows where to return to. -->
+                        <input type="hidden" name="returnUrl" value="<%= request.getRequestURL() %>" />
+                        <div class="label">
+                        </div>
+                        <div class="field">
+                            <br />
+                            <input name="resetAll" class="secondary" type="submit" border="0" hspace="5" value="Reset All Courses"/>
+                            <p tabIndex="0" class="stepHelp">Resets all courses previously provisioned to Panopto. This will unprovision all Panopto courses and delete their mapping from the Blackboard database. This operation cannot be undone.</p>
+                        </div>
+                    </li>
                 </ol>
             </div>
           </div>
@@ -813,7 +847,8 @@ else
 			                    <li>
 			                        <div class="jsSubmitButtonDiv">
 			                        	<input name="save-and-return" class="submit button-1" type="submit" value="Save general settings" onclick="document.location='<%=Utils.buildingBlockManagerURL%>';"/>
-			                            <input class="button-1" type="button" name="bottom_Return" role="button" value="Return to Block Manager" onclick="window.location.href='<%=Utils.buildingBlockManagerURL%>';" />
+                                        <input class="button-1" type="button" name="bottom_Return" role="button" value="Return to Block Manager" onclick="window.location.href='<%=Utils.buildingBlockManagerURL%>';" />
+                                        <input class="button-1" type="button" name="bottom_Logs" role="button" value="View Panopto block logs" onclick="window.location.href='<%=LogsAddress%>';" />
 			                        </div>
 			                    </li>
 			                </ol>

--- a/WebRoot/Course_Reset.jsp
+++ b/WebRoot/Course_Reset.jsp
@@ -75,7 +75,7 @@ if (!ccCourse.userMayConfig())
 <%
 } else {
     // Reset the course to have no Panopto configuration.
-    ccCourse.resetCourse(); %>
+    ccCourse.resetCourse(true); %>
     <bbUI:docTemplate title="<%=page_title%>">
         <bbUI:receipt type="PASS" iconUrl="<%=iconUrl%>" title="<%=page_title%>" recallUrl="<%=parentURL%>">
             This course has been reset.

--- a/WebRoot/Item_Create.jsp
+++ b/WebRoot/Item_Create.jsp
@@ -25,6 +25,7 @@
 <%@page import="blackboard.persist.Id"%>
 <%@page import="blackboard.data.course.Course"%>
 <%@page import="com.panopto.blackboard.PanoptoData"%>
+<%@page import="com.panopto.services.SessionManagementStub.Folder"%>
 
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 
@@ -151,6 +152,9 @@ if(lectureURL != null)
 			}
 			else
 			{
+
+				Folder[] mappedFolders = ccCourse.getFolders();
+				ccCourse.updateCourseFolders(mappedFolders);
 			 %>	
 			 
  			<form name="folderForm" id="folderForm">

--- a/WebRoot/SSO.jsp
+++ b/WebRoot/SSO.jsp
@@ -35,18 +35,22 @@
 	String expiration = request.getParameter("expiration");
 	String requestAuthCode = request.getParameter("authCode");
 
-	String action = request.getParameter("action");
+    String action = request.getParameter("action");
+    String triedAuth = request.getParameter("triedAuth");
+    
 	boolean relogin = (action != null) && action.equals("relogin") && Utils.pluginSettings.getRefreshLogins();
+	boolean inLoop = (triedAuth != null) && triedAuth.equals("true");
 
 	// Bounce unauthenticated/guest users and forced login requests through the login page.
 	BbSession bbSession = BbSessionManagerServiceFactory.getInstance().getSession(request);
-	if (!bbSession.isAuthenticated() || bbSession.getUserName().equals("guest") || relogin)
+	if (!inLoop && (!bbSession.isAuthenticated() || bbSession.getUserName().equals("guest") || relogin))
 	{
 		// Put callbackURL last so it doesn't eat the rest of the params when Blackboard erroneously double-decodes it.
 		String selfURL = request.getRequestURI() + 
 							"?authCode=" + requestAuthCode +
 							"&serverName=" + serverName +
 							"&expiration=" + expiration +
+							"&triedAuth=true" +
 							"&callbackURL=" + URLEncoder.encode(callbackURL, "UTF-8");
 
 		String returnURL = URLEncoder.encode(selfURL, "UTF-8");

--- a/WebRoot/WEB-INF/bb-manifest.xml
+++ b/WebRoot/WEB-INF/bb-manifest.xml
@@ -5,7 +5,7 @@
         <description value="Provision Panopto courses from Blackboard.  View live listing of available Panopto content from within the associated Blackboard course.  Import Panopto lecture links as Blackboard content items." />
         <handle value="PanoptoCourseTool" />
         <webapp-type value="javaext" />
-        <version value="2021.12.1" />
+        <version value="2022.12.1" />
         <requires>
             <bbversion value="9.1" />
         </requires>
@@ -75,6 +75,18 @@
                         <name value="Panopto Tool Settings" />
                         <url value="Config.jsp" />
                         <description value="Settings for the Panopto tool" />
+                        <entitlement-uid value="system.panopto.EXECUTE" />
+                    </link>
+                </links>
+            </application>
+            <application handle="PanoptoCourseToolAppLogs" type="system" name="Panopto Course Tool Logs">
+                <description>Panopto Course Tool Config</description>
+                <links>
+                    <link>
+                        <type value="system_tool" />
+                        <name value="Panopto Tool Logs" />
+                        <url value="Logs.jsp" />
+                        <description value="Logs for the Panopto tool" />
                         <entitlement-uid value="system.panopto.EXECUTE" />
                     </link>
                 </links>

--- a/WebRoot/content/mashup.jsp
+++ b/WebRoot/content/mashup.jsp
@@ -59,11 +59,7 @@
             }
         }
     }
-    else{
-    %>
-    <script> AlertAndRedirect();</script>
-    <%
-    }
+    
     //Generate source URL for iframe from info. Blackboard embeds require https
     String IFrameSrc = "https://" +serverName +"/Panopto/Pages/Sessions/EmbeddedUpload.aspx?playlistsEnabled=true&singleEmbedOnly=true&instance=" + Utils.pluginSettings.getInstanceName() + folderId;
 %>

--- a/src/main/com/panopto/blackboard/PanoptoCourseEventListener.java
+++ b/src/main/com/panopto/blackboard/PanoptoCourseEventListener.java
@@ -21,6 +21,7 @@ package com.panopto.blackboard;
 import blackboard.admin.persist.course.CloneConfig;
 import blackboard.admin.persist.course.CourseEventListener;
 import blackboard.data.course.Course;
+import blackboard.data.course.Course.UltraStatus;
 import blackboard.data.course.CourseManager;
 import blackboard.data.course.CourseManagerFactory;
 import blackboard.persist.Id;
@@ -52,28 +53,42 @@ public class PanoptoCourseEventListener implements CourseEventListener {
         CourseManager manager = CourseManagerFactory.getInstance();
         
         Course targetCourse = manager.getCourse(targetId);
-        PanoptoData targetCourseData = new PanoptoData(targetCourse, userName);
+        UltraStatus targetUltraStatus = targetCourse.getUltraStatus();
         
         Course sourceCourse = manager.getCourse(sourceId);
-        PanoptoData sourceCourseData = new PanoptoData(sourceCourse, userName);
+        UltraStatus sourceUltraStatus = sourceCourse.getUltraStatus();
         
-        // Even if course copy is not enabled by Panopto blackboard will copy all data base registries including Panopto ones, so we need to clean them up.
-        targetCourseData.handleCopyRegistryChanges(sourceCourseData);
+        if (targetUltraStatus.isClassic() && sourceUltraStatus.isClassic()) {
+            PanoptoData targetCourseData = new PanoptoData(targetCourse, userName);
+            PanoptoData sourceCourseData = new PanoptoData(sourceCourse, userName);
+            
+            // Even if course copy is not enabled by Panopto blackboard will copy all data base registries including Panopto ones, so we need to clean them up.
+            targetCourseData.handleCopyRegistryChanges(sourceCourseData);
+            
+            // Copy over permissions if the course copy setting is enabled for the site.
+            if (Utils.pluginSettings.getCourseCopyEnabled()) {
+                if (sourceCourseData.isMapped()) {
+                    if(!targetCourseData.isMapped()) {
+                        Utils.log("Target course with Id (" + targetCourse.getCourseId() + ") was not provisioned, we are provisioning it to a default folder before handling the import!");
+                        targetCourseData.provisionCourse(sourceCourseData.getServerName());
+                    }
+                    // Get the target course so we can copy into it from the source.
+                    targetCourseData.copyCoursePermissions(sourceCourse);
         
-        // Copy over permissions if the course copy setting is enabled for the site.
-        if (Utils.pluginSettings.getCourseCopyEnabled()) {
-            if (sourceCourseData.isMapped()) {
-                if(!targetCourseData.isMapped()) {
-                    Utils.log("Target course with Id (" + targetCourse.getCourseId() + ") was not provisioned, we are provisioning it to a default folder before handling the import!");
-                    targetCourseData.provisionCourse(sourceCourseData.getServerName());
+                    Utils.log(String.format("Course Cloned. Source ID: %s Target ID: %s", sourceId.toExternalString(),
+                            targetId.toExternalString()));
+                } else {
+                    Utils.log("Source course with Id (" + sourceCourse.getCourseId() + ") was not provisioned, Blackboard course copy can continue, however Panopto course copy has no folders to copy.");
                 }
-                // Get the target course so we can copy into it from the source.
-                targetCourseData.copyCoursePermissions(sourceCourse);
-    
-                Utils.log(String.format("Course Cloned. Source ID: %s Target ID: %s", sourceId.toExternalString(),
-                        targetId.toExternalString()));
+            }
+        } else {
+            if (!targetUltraStatus.isClassic() && !sourceUltraStatus.isClassic()) {
+                Utils.log("Course Copy/Import attempted but both target course with Id (" + targetCourse.getCourseId() + ") and source course with Id (" + sourceCourse.getCourseId() + ")" 
+                        +  " are set to use Ultra when Ultra courses are not supported by the Panopto building block.");
+            } else if (!targetUltraStatus.isClassic()) {
+                Utils.log("Course Copy/Import attempted but target course with Id (" + targetCourse.getCourseId() + ") is set to use Ultra when Ultra courses are not supported by the Panopto building block.");
             } else {
-                Utils.log("Source course with Id (" + sourceCourse.getCourseId() + ") was not provisioned, Blackboard course copy can continue, however Panopto course copy has no folders to copy.");
+                Utils.log("Course Copy/Import attempted but source course with Id (" + sourceCourse.getCourseId() + ") is set to use Ultra when Ultra course are not supported by the Panopto building block.");
             }
         }
     }


### PR DESCRIPTION
This is the latest stable release of the Panopto plugin for Blackboard, which is recommended to all customers.

This plugin fully supports Blackboard Learn 9.1 3900, Q4 2019 (build 3800), and Blackboard SaaS.

This plugin does not work with Ultra experience courses on Blackboard SaaS environments.

Note that the support versions may change over the lifetime of this plugin. Please [refer to this support article](https://support.panopto.com/s/article/Panopto-Blackboard-Integration-Support-Policy) for more details.

- Fixed a bug that could cause Blackboard Ultra courses to be accidentally provisioned by the Panopto plugin for Blackboard if a course was copied, and either the source or target of the copy was a Blackboard Classic course, and the other was a Blackboard Ultra course.
- Fixed an issue that could cause a login loop in some cases when attempting to automatically log a user into Panopto through a video embedded in a Blackboard course.
- Added additional validation and checks when adding a hostname in the Panopto plugin for Blackboard settings. The Building Block will now check that the hostname is in the correct format, and ensure it is lower case to avoid errors with provisioning.
- Added a new error message if a course fails to be provisioned due to a timeout on the operation. Previously, the operation would fail silently.
- Added a link to the Panopto plugin logs to the Building Block settings for the Panopto Plugin.