### PR TITLE
2023.6.1 release code.

### DIFF
--- a/WebRoot/Bulk_LTI_Link.jsp
+++ b/WebRoot/Bulk_LTI_Link.jsp
@@ -1,0 +1,96 @@
+<!-- Copyright Panopto 2009 - 2016
+ * 
+ * This file is part of the Panopto plugin for Blackboard.
+ * 
+ * The Panopto plugin for Blackboard is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Panopto plugin for Blackboard is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Panopto plugin for Blackboard.  If not, see <http://www.gnu.org/licenses/>.
+ */ -->
+
+<%@page import="java.util.Arrays"%>
+<%@page language="java" pageEncoding="ISO-8859-1" %>
+
+<%@page import="com.panopto.blackboard.Utils"%>
+<%@page import="com.panopto.blackboard.PanoptoCourseSearch"%>
+<%@page import="blackboard.data.course.Course"%>
+<%@page import="java.util.List"%>
+<%@page import="java.util.ArrayList"%>
+<%@page import="com.panopto.blackboard.PanoptoData"%>
+<%@page import="com.panopto.services.*"%>
+
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+
+<%@taglib uri="/bbUI" prefix="bbUI" %>
+<%@taglib uri="/bbData" prefix="bbData"%>
+
+<%
+String iconUrl = "/images/ci/icons/bookopen_u.gif";
+String page_title = "Bulk LTI Navigation Link on Provisioned Courses";
+
+String returnUrl = request.getParameter("returnUrl");
+%>
+<bbUI:coursePage>
+    <bbData:context id="ctx">
+        <bbUI:docTemplate title="<%=page_title%>">
+        <c:catch>
+            <bbUI:docTemplateHead>
+                <link rel="stylesheet" type="text/css" href="css/main.css" />
+            </bbUI:docTemplateHead>
+
+            <bbUI:titleBar iconUrl="<%=iconUrl%>">
+                <%=page_title%>
+            </bbUI:titleBar>
+        </c:catch>
+<%
+
+if (!Utils.userCanConfigureSystem())
+{
+    %><div class='error'>Error. You do not have access to create an LTI link for courses.</div><%
+}
+else
+{
+    %>
+            <div id='bulkLTILinkResultsHeader'>LTI Link Results:</div>
+            <div id='bulkLTILinkResults'>
+    <%
+    
+    java.util.List<Course> allCourses = PanoptoCourseSearch.GetAllCourses();
+    if (allCourses.size() == 0)
+    {
+        %><div class='errorMessage'>Unable to retrieve list of provisioned Blackboard courses</div><%
+    }
+    
+    for (Course course : allCourses)
+    {
+        if (PanoptoData.HasPanoptoServer(course))
+        {
+            PanoptoData ccCourse = new PanoptoData(course, ctx.getUser().getUserName());
+            
+            if (ccCourse.addCourseMenuLTILink()) {
+                %><div class='successMessage'>Added LTI link to course <%= ccCourse.getBBCourse().getCourseId() %>: <%= ccCourse.getBBCourse().getTitle() %></div><%
+            } else {
+                %><div class='errorMessage'>Unable to add LTI link for course <%= ccCourse.getBBCourse().getCourseId() %>: <%= ccCourse.getBBCourse().getTitle() %>. Please see Panopto block logs for more details.</div><%
+            }
+        }
+    }
+
+    %>
+            </div>
+    <%  
+}
+ %>
+        <div>
+            <bbUI:button type="INLINE" name="OK" alt="OK" action="LINK" targetUrl="<%=returnUrl%>" />
+        </div>
+        </bbUI:docTemplate>
+    </bbData:context>
+</bbUI:coursePage>

--- a/WebRoot/Bulk_List_Link.jsp
+++ b/WebRoot/Bulk_List_Link.jsp
@@ -1,0 +1,96 @@
+<!-- Copyright Panopto 2009 - 2016
+ * 
+ * This file is part of the Panopto plugin for Blackboard.
+ * 
+ * The Panopto plugin for Blackboard is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Panopto plugin for Blackboard is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Panopto plugin for Blackboard.  If not, see <http://www.gnu.org/licenses/>.
+ */ -->
+
+<%@page import="java.util.Arrays"%>
+<%@page language="java" pageEncoding="ISO-8859-1" %>
+
+<%@page import="com.panopto.blackboard.Utils"%>
+<%@page import="com.panopto.blackboard.PanoptoCourseSearch"%>
+<%@page import="blackboard.data.course.Course"%>
+<%@page import="java.util.List"%>
+<%@page import="java.util.ArrayList"%>
+<%@page import="com.panopto.blackboard.PanoptoData"%>
+<%@page import="com.panopto.services.*"%>
+
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+
+<%@taglib uri="/bbUI" prefix="bbUI" %>
+<%@taglib uri="/bbData" prefix="bbData"%>
+
+<%
+String iconUrl = "/images/ci/icons/bookopen_u.gif";
+String page_title = "Bulk Folder List Navigation Links on Provisioned Courses";
+
+String returnUrl = request.getParameter("returnUrl");
+%>
+<bbUI:coursePage>
+    <bbData:context id="ctx">
+        <bbUI:docTemplate title="<%=page_title%>">
+        <c:catch>
+            <bbUI:docTemplateHead>
+                <link rel="stylesheet" type="text/css" href="css/main.css" />
+            </bbUI:docTemplateHead>
+
+            <bbUI:titleBar iconUrl="<%=iconUrl%>">
+                <%=page_title%>
+            </bbUI:titleBar>
+        </c:catch>
+<%
+
+if (!Utils.userCanConfigureSystem())
+{
+    %><div class='error'>Error. You do not have access to create an list links for courses.</div><%
+}
+else
+{
+    %>
+            <div id='bulkListLinkResultsHeader'>Folder List Link Results:</div>
+            <div id='bulkListLinkResults'>
+    <%
+    
+    java.util.List<Course> allCourses = PanoptoCourseSearch.GetAllCourses();
+    if (allCourses.size() == 0)
+    {
+        %><div class='errorMessage'>Unable to retrieve list of provisioned Blackboard courses</div><%
+    }
+    
+    for (Course course : allCourses)
+    {
+        if (PanoptoData.HasPanoptoServer(course))
+        {
+            PanoptoData ccCourse = new PanoptoData(course, ctx.getUser().getUserName());
+            
+            if (ccCourse.addCourseMenuFolderListLinks()) {
+                %><div class='successMessage'>Added folder list links to course <%= ccCourse.getBBCourse().getCourseId() %>: <%= ccCourse.getBBCourse().getTitle() %></div><%
+            } else {
+                %><div class='errorMessage'>Unable to add folder list links for course <%= ccCourse.getBBCourse().getCourseId() %>: <%= ccCourse.getBBCourse().getTitle() %>. Please see Panopto block logs for more details.</div><%
+            }
+        }
+    }
+
+    %>
+            </div>
+    <%  
+}
+ %>
+        <div>
+            <bbUI:button type="INLINE" name="OK" alt="OK" action="LINK" targetUrl="<%=returnUrl%>" />
+        </div>
+        </bbUI:docTemplate>
+    </bbData:context>
+</bbUI:coursePage>

--- a/WebRoot/Config.jsp
+++ b/WebRoot/Config.jsp
@@ -78,6 +78,8 @@ Boolean TAsCanCreateLinks = (request.getParameter("TAsCanCreateLinks") != null);
 Boolean courseResetEnabled = (request.getParameter("courseResetEnabled") != null);
 Boolean verbose = (request.getParameter("verbose") != null);
 Boolean insertLinkOnProvision = (request.getParameter("insertLinkOnProvision") != null);
+Boolean insertLTILinkOnProvision = (request.getParameter("insertLTILinkOnProvision") != null);
+Boolean insertFolderLinkOnProvision = (request.getParameter("insertFolderLinkOnProvision") != null);
 Boolean videoLinkToolIncludeCreatorFolders = (request.getParameter("videoLinkToolIncludeCreatorFolders") != null);
 String menuLinkText = request.getParameter("menuLinkText");
 String roleMappingString = request.getParameter("roleMappingString");
@@ -122,6 +124,8 @@ if(instanceName != null)
 	Utils.pluginSettings.setCourseResetEnabled(courseResetEnabled);
 	Utils.pluginSettings.setVerbose(verbose);
 	Utils.pluginSettings.setInsertLinkOnProvision(insertLinkOnProvision);
+    Utils.pluginSettings.setInsertLTILinkOnProvision(insertLTILinkOnProvision);
+    Utils.pluginSettings.setInsertFolderLinkOnProvision(insertFolderLinkOnProvision);
 	Utils.pluginSettings.setVideoLinkToolIncludeCreatorFolders(videoLinkToolIncludeCreatorFolders);
 	Utils.pluginSettings.setCourseCopyEnabled(courseCopyEnabled);
 	
@@ -169,6 +173,8 @@ TAsCanCreateLinks = Utils.pluginSettings.getTAsCanCreateLinks();
 courseResetEnabled = Utils.pluginSettings.getCourseResetEnabled();
 verbose = Utils.pluginSettings.getVerbose();
 insertLinkOnProvision = Utils.pluginSettings.getInsertLinkOnProvision();
+insertLTILinkOnProvision = Utils.pluginSettings.getInsertLTILinkOnProvision();
+insertFolderLinkOnProvision = Utils.pluginSettings.getInsertFolderLinkOnProvision();
 videoLinkToolIncludeCreatorFolders = Utils.pluginSettings.getVideoLinkToolIncludeCreatorFolders();
 menuLinkText = Utils.pluginSettings.getMenuLinkText();
 roleMappingString = Utils.pluginSettings.getRoleMappingString();
@@ -474,6 +480,55 @@ else
           </div>
     </form>
     
+    <!-- Post to breakout bulk LTI nav link page. -->
+    <form name="bulkLTIForm" action="Bulk_LTI_Link.jsp" method="post">
+         <div class="form">
+            <div class="steptitle submittitle" id="steptitle2">
+                <span id="stepnumber2">2</span>
+                Add LTI navigation link to all provisioned courses
+            </div>
+            <div class="stepcontent" id="step2">
+                <ol>
+                    <li><!-- URL of current page so provision breakout page knows where to return to. -->
+                        <input type="hidden" name="returnUrl" value="<%= request.getRequestURL() %>" />
+                        <div class="label">
+                        </div>
+                        <div class="field">
+                            <br />
+                            <input name="ltiLinkAll" class="secondary" type="submit" border="0" hspace="5" value="Add LTI Link to all courses"/>
+                            <p tabIndex="0" class="stepHelp">Adds an LTI navigation link to the table of contents menu for all provisioned courses. <br />
+                            Note: This feature requires an LTI Tool Provider and corresponding Course Tool placement for the provisioned Panopto server to work properly.</p>
+                        </div>
+                    </li>
+                </ol>
+            </div>
+          </div>
+    </form>
+    
+    <!-- Post to breakout bulk folder list nav link page. -->
+    <form name="bulkListLinkForm" action="Bulk_List_Link.jsp" method="post">
+         <div class="form">
+            <div class="steptitle submittitle" id="steptitle2">
+                <span id="stepnumber2">2</span>
+                Add non-LTI Folder list navigation links to all provisioned courses
+            </div>
+            <div class="stepcontent" id="step2">
+                <ol>
+                    <li><!-- URL of current page so provision breakout page knows where to return to. -->
+                        <input type="hidden" name="returnUrl" value="<%= request.getRequestURL() %>" />
+                        <div class="label">
+                        </div>
+                        <div class="field">
+                            <br />
+                            <input name="folderListLinkAll" class="secondary" type="submit" border="0" hspace="5" value="Add Folder List Link to all courses"/>
+                            <p tabIndex="0" class="stepHelp">Adds non-LTI navigation links for each provisioned folder to the table of contents menu for all provisioned courses. <br />
+                        </div>
+                    </li>
+                </ol>
+            </div>
+          </div>
+    </form>
+    
     <form name="instanceForm">
          <div class="form">
             <div class="steptitle submittitle" id="steptitle3">
@@ -537,6 +592,39 @@ else
                         <div class="field">
                             <p tabIndex="0" class="stepHelp">
                                When checked, a link to a course's Panopto content will be automatically inserted into the course's navigation menu when it is provisioned.<br/>
+                                <br/>
+                                <br/>
+                            </p>
+                        </div>
+                    </li>
+                    
+                    <li>
+                        <div class="label">Panopto LTI link on course menu when provisioned</div>
+                        <div class="field">
+                            <input name="insertLTILinkOnProvision" type="checkbox" <%= insertLTILinkOnProvision ? "checked" : "" %> style="float:left" />
+                        </div>
+                    </li>
+                    <li>
+                        <div class="field">
+                            <p tabIndex="0" class="stepHelp">
+                               When checked, a LTI link to a course's Panopto content will be automatically inserted into the course's navigation menu when it is provisioned. <br />
+                            Note: This feature requires an LTI Tool Provider and corresponding Course Tool placement for the provisioned Panopto server to work properly. <br />
+                                <br/>
+                                <br/>
+                            </p>
+                        </div>
+                    </li>
+                    
+                    <li>
+                        <div class="label">Panopto non-LTI folder list links on course menu when provisioned</div>
+                        <div class="field">
+                            <input name="insertFolderLinkOnProvision" type="checkbox" <%= insertFolderLinkOnProvision ? "checked" : "" %> style="float:left" />
+                        </div>
+                    </li>
+                    <li>
+                        <div class="field">
+                            <p tabIndex="0" class="stepHelp">
+                               When checked, non-LTI links to a course's Panopto content for each provisioned folder will be automatically inserted into the course's navigation menu when it is provisioned. <br />
                                 <br/>
                                 <br/>
                             </p>

--- a/WebRoot/Course_Config.jsp
+++ b/WebRoot/Course_Config.jsp
@@ -294,6 +294,7 @@ if(folderIds != null)
                                                     <%= ccCourse.generateCourseConfigAvailableFoldersOptionsHTML() %>
 	                                              <%} catch(Exception e) {
 	                                                 failedReconfigure = true;
+	                                                 Utils.log(e, "Error on generateCourseConfigAvailableFoldersOptionsHTML");
 	                                              }%>
                                               </SELECT>
                                         </td>
@@ -309,6 +310,7 @@ if(folderIds != null)
                                                     <%= ccCourse.generateCourseConfigSelectedFoldersOptionsHTML() %>
                                                   <%} catch(Exception e) {
                                                      failedReconfigure = true;
+                                                     Utils.log(e, "Error on generateCourseConfigSelectedFoldersOptionsHTML");
                                                   }%>
                                                 
                                               </SELECT>
@@ -419,6 +421,7 @@ if(folderIds != null)
                                                  <%=ccCourse.generateCourseConfigCopyFoldersOptionsHTML()%>
                                             <%} catch(Exception e) {
                                                  failedReconfigure = true;
+                                                 Utils.log(e, "Error on generateCourseConfigCopyFoldersOptionsHTML");
                                               }%>
                                               </SELECT>
                                           </td>

--- a/WebRoot/WEB-INF/bb-manifest.xml
+++ b/WebRoot/WEB-INF/bb-manifest.xml
@@ -5,7 +5,7 @@
         <description value="Provision Panopto courses from Blackboard.  View live listing of available Panopto content from within the associated Blackboard course.  Import Panopto lecture links as Blackboard content items." />
         <handle value="PanoptoCourseTool" />
         <webapp-type value="javaext" />
-        <version value="2022.12.1" />
+        <version value="2023.6.1" />
         <requires>
             <bbversion value="9.1" />
         </requires>

--- a/src/main/com/panopto/blackboard/Settings.java
+++ b/src/main/com/panopto/blackboard/Settings.java
@@ -87,6 +87,12 @@ public class Settings {
     // Insert a link to panopto tool on course page when a course is provisioned
     private Boolean insertLinkOnProvision = false;
 
+    // Insert a link to panopto LTI tool on course page when a course is provisioned
+    private Boolean insertLTILinkOnProvision = false;
+
+    // Insert a link to panopto non-LTI folder list link on course page when a course is provisioned
+    private Boolean insertFolderLinkOnProvision = false;
+
     // Whether or not the Panopto Link tool uses Mapped + Public or Mapped + Creator folders. 
     private Boolean videoLinkToolIncludeCreatorFolders = false;
 
@@ -297,6 +303,24 @@ public class Settings {
         save();
     }
 
+    public Boolean getInsertLTILinkOnProvision() {
+        return insertLTILinkOnProvision;
+    }
+
+    public void setInsertLTILinkOnProvision(Boolean insertLTILinkOnProvision) {
+        this.insertLTILinkOnProvision = insertLTILinkOnProvision;
+        save();
+    }
+
+    public Boolean getInsertFolderLinkOnProvision() {
+        return insertFolderLinkOnProvision;
+    }
+
+    public void setInsertFolderLinkOnProvision(Boolean insertFolderLinkOnProvision) {
+        this.insertFolderLinkOnProvision = insertFolderLinkOnProvision;
+        save();
+    }
+
     public Boolean getVideoLinkToolIncludeCreatorFolders() {
         return videoLinkToolIncludeCreatorFolders;
     }
@@ -444,6 +468,14 @@ public class Settings {
             Element insertLinkOnProvisionElem = settingsDocument.createElement("insertLinkOnProvision");
             insertLinkOnProvisionElem.setAttribute("insertLinkOnProvision", insertLinkOnProvision.toString());
             docElem.appendChild(insertLinkOnProvisionElem);
+
+            Element insertLTILinkOnProvisionElem = settingsDocument.createElement("insertLTILinkOnProvision");
+            insertLTILinkOnProvisionElem.setAttribute("insertLTILinkOnProvision", insertLTILinkOnProvision.toString());
+            docElem.appendChild(insertLTILinkOnProvisionElem);
+
+            Element insertFolderLinkOnProvisionElem = settingsDocument.createElement("insertFolderLinkOnProvision");
+            insertFolderLinkOnProvisionElem.setAttribute("insertFolderLinkOnProvision", insertFolderLinkOnProvision.toString());
+            docElem.appendChild(insertFolderLinkOnProvisionElem);
 
             Element videoLinkToolIncludeCreatorFoldersElem = settingsDocument.createElement("videoLinkToolIncludeCreatorFolders");
             videoLinkToolIncludeCreatorFoldersElem.setAttribute("videoLinkToolIncludeCreatorFolders", videoLinkToolIncludeCreatorFolders.toString());
@@ -595,6 +627,20 @@ public class Settings {
             Element insertLinkOnProvisionElem = (Element) insertLinkOnProvisionNodes.item(0);
             this.insertLinkOnProvision = Boolean
                     .valueOf(insertLinkOnProvisionElem.getAttribute("insertLinkOnProvision"));
+        }
+
+        NodeList insertLTILinkOnProvisionNodes = docElem.getElementsByTagName("insertLTILinkOnProvision");
+        if (insertLTILinkOnProvisionNodes.getLength() != 0) {
+            Element insertLTILinkOnProvisionElem = (Element) insertLTILinkOnProvisionNodes.item(0);
+            this.insertLTILinkOnProvision = Boolean
+                    .valueOf(insertLTILinkOnProvisionElem.getAttribute("insertLTILinkOnProvision"));
+        }
+
+        NodeList insertFolderLinkOnProvisionNodes = docElem.getElementsByTagName("insertFolderLinkOnProvision");
+        if (insertFolderLinkOnProvisionNodes.getLength() != 0) {
+            Element insertFolderLinkOnProvisionElem = (Element) insertFolderLinkOnProvisionNodes.item(0);
+            this.insertFolderLinkOnProvision = Boolean
+                    .valueOf(insertFolderLinkOnProvisionElem.getAttribute("insertFolderLinkOnProvision"));
         }
 
         NodeList videoLinkToolIncludeCreatorFoldersNodes = docElem.getElementsByTagName("videoLinkToolIncludeCreatorFolders");


### PR DESCRIPTION
This is the latest stable release of the Panopto plugin for Blackboard, which is recommended to all customers.

This plugin fully supports Blackboard Learn 9.1 3900, Q4 2019 (build 3800), and Blackboard SaaS.

This plugin does not work with Ultra experience courses on Blackboard SaaS environments.

Note that the support versions may change over the lifetime of this plugin. Please [refer to this support article](https://support.panopto.com/s/article/Panopto-Blackboard-Integration-Support-Policy) for more details.

- Added a new tool on the Panopto Building Block Settings page to bulk-create either LTI or direct links to a course folder in Blackboard Original courses, in order to help support migration to the new Blackboard Ultra integration for Blackboard Original courses in advance of the deprecation of the Building Blocks for Blackboard. These links do not use the Panopto Building Block, and can be used after the Building Blocks for Blackboard have been deprecated
- Added the option to create an LTI folder link or a direct link to the course folder when a Blackboard Original course is provisioned or reprovisioned. These links do not use the Panopto Building Block, and can be used after the Building Blocks for Blackboard have been deprecated.